### PR TITLE
Add Authentik identity migration groundwork and update production deploy flow

### DIFF
--- a/.github/workflows/docs-site-pages.yml
+++ b/.github/workflows/docs-site-pages.yml
@@ -34,8 +34,6 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
-        with:
-          enablement: true
 
       - name: Install dependencies
         working-directory: docs-site

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.4] - 2026-04-27
+
+### Added
+
+- Added Authentik migration architecture documentation in `docs/architecture/ADR-005-suite-identity-migration.md`.
+- Added transitional backend identity resolution support for future Authentik-issued tokens.
+- Added `authentikSub` and provider-linking support to the local DocMan user model.
+- Added a CLI script and admin API/UI workflow for linking existing DocMan users to Authentik identities.
+- Added an Authentik PKCE login path in `frontend-vue` for suite-level sign-in.
+- Added a reusable MongoDB TLS helper script in `scripts/setup-mongodb-ssl/setup-mongodb-ssl.sh`.
+
+### Changed
+
+- Updated `apache_production_deploy.sh` to align with the current RDocMan architecture.
+- Changed the deployment script to build and publish `frontend-vue` instead of the legacy frontend.
+- Changed the deployment script to publish `frontend-vue/dist-remote/remote/` for the RDSysCMD hybrid desktop module.
+- Changed the deployment script to recreate `docman-backend.service` with the `docman` service user.
+- Changed the deployment script to detect and reuse an existing MongoDB server configuration when available.
+- Changed the deployment script to reuse prior `.env.prod` values from the latest deployment backup as prompt defaults when available.
+- Tightened the documented and scripted Node.js requirement to `20.19+` or `22.12+` for the current Vue/Vite toolchain.
+- Updated deployment documentation and README guidance to reflect the current Vue/Vuetify, Authentik, and hybrid remote-bundle deployment path.
+
 ## [0.2.3] - 2026-04-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ DocMan is also the baseline UI guidepost for the larger Resonance Designs local 
 
 ### Prerequisites
 
-- Node.js 18+
+- Node.js 20.19+ or 22.12+
 - npm
 - MongoDB 4.4+
 
@@ -134,9 +134,17 @@ MONGO_ATLAS_APP=<app-name>
 
 ```env
 VITE_API_URL=http://localhost:5001/api
+VITE_AUTHENTIK_ENABLED=false
+VITE_AUTHENTIK_CLIENT_ID=rdocman-web
+VITE_AUTHENTIK_AUTHORIZATION_URL=https://accounts.resonancedesigns.dev/application/o/authorize/
+VITE_AUTHENTIK_TOKEN_URL=https://accounts.resonancedesigns.dev/application/o/token/
+VITE_AUTHENTIK_REDIRECT_URI=http://localhost:5174/auth/callback
+VITE_AUTHENTIK_SCOPE=openid profile email
 ```
 
 The Vue/Vuetify frontend defaults to the current browser hostname on port `5001` during development. This allows both `http://localhost:5174` and `http://127.0.0.1:5174` to call the backend. The backend CORS development allowlist includes both localhost and loopback origins for ports `3000`, `5173`, and `5174`.
+
+When Authentik is enabled in the Vue frontend, the login view will expose a "Sign in with Resonance Account" path. The frontend uses Authorization Code + PKCE and expects the backend to accept Authentik-issued access tokens that resolve to linked local RDocMan users through `authentikSub`.
 
 ## 🧭 Suite UI Migration
 
@@ -173,7 +181,7 @@ Download them and then upload them somewhere on your server, like your users hom
 
 | Script | Purpose | Notes |
 |--------|---------|------|
-| [`apache_production_deploy.sh`](https://github.com/resonance-designs/docman/releases/download/latest/apache_production_deploy.sh) | Initial deployment of DocMan to a fresh server | Use this for first-time setup. Installs backend, frontend, and environment variables. |
+| [`apache_production_deploy.sh`](https://github.com/resonance-designs/docman/releases/download/latest/apache_production_deploy.sh) | Initial deployment of DocMan to a fresh server | Use this for first-time setup or to recover a broken deployment tree. Clones a fresh repo copy, rebuilds the Vue frontend, publishes the remote bundle, and recreates the backend service definition. |
 | [`apache_production_update.sh`](https://github.com/resonance-designs/docman/releases/download/latest/apache_production_update.sh) | Standard interactive update | Updates an existing production instance. Prompts for confirmations. Optional SSL update. |
 | [`apache_production_update_ni.sh`](https://github.com/resonance-designs/docman/releases/download/latest/apache_production_update_ni.sh) | Non-interactive automated update | Fully automated update without prompts. Supports optional SSL and `--dry-run` for testing. Automatically rolls back on errors. |
 
@@ -200,6 +208,9 @@ sudo ./apache_production_deploy.sh
 * Installs backend and frontend on a fresh server.
 * Sets up environment variables (`.env.prod`) from `.env.sample.`
 * Optionally sets up SSL certificates.
+* Clones a fresh repository checkout into `/var/www/docman`.
+* Builds `frontend-vue` and `frontend-vue/dist-remote/remote/`.
+* Republishes the remote bundle used by `RDSysCMD`.
 
 #### 2️⃣ Standard Interactive Update
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 __by Resonance Designs__
 
-![Static Badge](https://img.shields.io/badge/Version-2.2.3-orange)
-![Static Badge](https://img.shields.io/badge/Latest_Release-v2.2.3-green)
+![Static Badge](https://img.shields.io/badge/Version-2.2.4-orange)
+![Static Badge](https://img.shields.io/badge/Latest_Release-v2.2.4-green)
 
 A modern, full-stack document management system built with Node.js, MongoDB, and a frontend currently migrating from React to Vue/Vuetify. DocMan provides secure document storage, collaborative workflows, and comprehensive review management.
 

--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -39,6 +39,11 @@ UPSTASH_REDIS_REST_TOKEN=<UPSTASH_REDIS_REST_TOKEN> # Token for Upstash Redis RE
 # Authentication Configuration
 JWT_SECRET=<AUTH_TOKEN> # Preferred JWT secret for production. Use a long secure random value.
 TOKEN_KEY=<AUTH_TOKEN> # Secret key for JWT or other authentication mechanisms. Can be any secure random string.
+AUTHENTIK_ISSUER=<AUTHENTIK_ISSUER> # Example: https://accounts.resonancedesigns.dev/application/o/rdocman-web/
+AUTHENTIK_AUDIENCE=<AUTHENTIK_AUDIENCE> # Usually the Authentik client ID / audience expected by DocMan
+AUTHENTIK_CLIENT_ID=<AUTHENTIK_CLIENT_ID> # Optional alias to keep client naming explicit
+AUTHENTIK_BASE_URL=<AUTHENTIK_BASE_URL> # Optional alias for issuer base if you standardize config this way
+AUTHENTIK_JWT_PUBLIC_KEY=<AUTHENTIK_JWT_PUBLIC_KEY> # PEM-encoded public key for verifying Authentik RS256 access tokens; escape newlines as \\n in env files if needed
 
 # AWS SES Configuration for Email Notifications
 AWS_ACCESS_KEY_ID=<AWS_ACCESS_KEY_ID> # Your AWS access key ID for SES

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rd-docman-backend",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rd-docman-backend",
-      "version": "2.2.3",
+      "version": "2.2.4",
       "license": "UNLICENSED",
       "dependencies": {
         "@aws-sdk/client-ses": "^3.864.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rdocman-backend",
   "private": true,
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "RDocMan is a document management application for all sorts of documents. Track updates, schedule reviews, categorize, and upload versions of your docs. DocMan hopes to be the most comprehensive piece of software to manage all of your documentation. You can schedule your documentation for review between stakeholders, the original authors, contributors, relevant tech leads, etc... Categorize, analyze, version repositories, and basically everything you would need to keep your documentation well organized, maintained, analyzed, and backed up.",
   "keywords": [
     "Document Management",

--- a/backend/package.json
+++ b/backend/package.json
@@ -43,6 +43,7 @@
     "send-review-notifications": "node scripts/sendReviewNotifications.js",
     "migrate-categories": "ATLAS=no NODE_ENV=development node src/scripts/migrateCategoryTypes.js",
     "migrate-review-fields": "ATLAS=no NODE_ENV=development node src/scripts/migrateReviewFields.js",
+    "link:authentik-users": "ATLAS=no NODE_ENV=development node src/scripts/linkAuthentikUsers.js",
     "create-book-categories": "ATLAS=no NODE_ENV=development node src/scripts/createBookCategory.js",
     "clear:users": "ATLAS=no NODE_ENV=development node src/scripts/clearData/clearUsers.js",
     "clear:books": "ATLAS=no NODE_ENV=development node src/scripts/clearData/clearBooks.js",

--- a/backend/src/__tests__/analytics.test.js
+++ b/backend/src/__tests__/analytics.test.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import request from "supertest";

--- a/backend/src/__tests__/auth.integration.test.js
+++ b/backend/src/__tests__/auth.integration.test.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import request from "supertest";

--- a/backend/src/__tests__/auth.test.js
+++ b/backend/src/__tests__/auth.test.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import request from "supertest";

--- a/backend/src/__tests__/categories.test.js
+++ b/backend/src/__tests__/categories.test.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import request from "supertest";

--- a/backend/src/__tests__/docs.test.js
+++ b/backend/src/__tests__/docs.test.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import request from "supertest";

--- a/backend/src/__tests__/externalContacts.test.js
+++ b/backend/src/__tests__/externalContacts.test.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import request from "supertest";

--- a/backend/src/__tests__/middleware/cacheMiddleware.test.js
+++ b/backend/src/__tests__/middleware/cacheMiddleware.test.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/__tests__/middleware/cacheMiddleware.test.js
  * @description Unit tests for caching middleware
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { jest } from '@jest/globals';

--- a/backend/src/__tests__/middleware/performanceMonitor.test.js
+++ b/backend/src/__tests__/middleware/performanceMonitor.test.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/__tests__/middleware/performanceMonitor.test.js
  * @description Unit tests for performance monitoring middleware
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { jest } from '@jest/globals';

--- a/backend/src/__tests__/notifications.test.js
+++ b/backend/src/__tests__/notifications.test.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import request from "supertest";

--- a/backend/src/__tests__/projects.test.js
+++ b/backend/src/__tests__/projects.test.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import request from "supertest";

--- a/backend/src/__tests__/services/documentService.test.js
+++ b/backend/src/__tests__/services/documentService.test.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/__tests__/services/documentService.test.js
  * @description Unit tests for document service business logic
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { jest } from '@jest/globals';

--- a/backend/src/__tests__/services/queryOptimizationService.test.js
+++ b/backend/src/__tests__/services/queryOptimizationService.test.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/__tests__/services/queryOptimizationService.test.js
  * @description Unit tests for query optimization service
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { jest } from '@jest/globals';

--- a/backend/src/__tests__/setup.js
+++ b/backend/src/__tests__/setup.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/__tests__/setup.js
  * @description Global test setup and configuration
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { jest } from '@jest/globals';

--- a/backend/src/__tests__/teams.test.js
+++ b/backend/src/__tests__/teams.test.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import request from "supertest";

--- a/backend/src/__tests__/users.test.js
+++ b/backend/src/__tests__/users.test.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import request from "supertest";

--- a/backend/src/config/database-indexes.js
+++ b/backend/src/config/database-indexes.js
@@ -4,7 +4,7 @@
  * @module database-indexes
  * @description Database index definitions for optimal query performance
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/config/db.js
+++ b/backend/src/config/db.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/config/swagger.js
+++ b/backend/src/config/swagger.js
@@ -4,7 +4,7 @@
  * @module swagger
  * @description OpenAPI/Swagger configuration for comprehensive API documentation
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import swaggerJsdoc from 'swagger-jsdoc';

--- a/backend/src/config/upstash.js
+++ b/backend/src/config/upstash.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import {Ratelimit} from "@upstash/ratelimit";

--- a/backend/src/controllers/analyticsController.js
+++ b/backend/src/controllers/analyticsController.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import Doc from "../models/Doc.js";

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -283,3 +283,29 @@ export async function logout(req, res) {
         res.status(500).json({ message: "Logout failed." });
     }
 }
+
+/**
+ * Return the current authenticated RDocMan session user.
+ * Works for both local DocMan JWTs and future Authentik-linked identities once request identity is resolved.
+ * @param {Object} req - Express request object
+ * @param {Object} res - Express response object
+ * @returns {Object} JSON response with current authenticated user
+ */
+export async function getCurrentSession(req, res) {
+    try {
+        if (!req.user) {
+            return res.status(401).json({ message: "Not authenticated" });
+        }
+
+        res.status(200).json({
+            user: req.user,
+            identity: req.identity ? {
+                authType: req.identity.authType,
+                provider: req.identity.provider,
+            } : null,
+        });
+    } catch (error) {
+        console.error("Get current session error:", error);
+        res.status(500).json({ message: "Failed to resolve current session." });
+    }
+}

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -4,7 +4,7 @@
  * @controller authController
  * @description Authentication controller handling user registration, login, logout, and password reset functionality
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import crypto from "crypto";

--- a/backend/src/controllers/booksController.js
+++ b/backend/src/controllers/booksController.js
@@ -4,7 +4,7 @@
  * @controller booksController
  * @description Book management controller for organizing documents into collections
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import Book from "../models/Book.js";

--- a/backend/src/controllers/categoriesController.js
+++ b/backend/src/controllers/categoriesController.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import Category from "../models/Category.js";

--- a/backend/src/controllers/customChartsController.js
+++ b/backend/src/controllers/customChartsController.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import CustomChart from "../models/CustomChart.js";

--- a/backend/src/controllers/docsController.js
+++ b/backend/src/controllers/docsController.js
@@ -4,7 +4,7 @@
  * @controller docsController
  * @description Document management controller for CRUD operations, file uploads, version control, and review workflows
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import Doc from "../models/Doc.js";

--- a/backend/src/controllers/externalContactsController.js
+++ b/backend/src/controllers/externalContactsController.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import ExternalContact from "../models/ExternalContact.js";

--- a/backend/src/controllers/notificationsController.js
+++ b/backend/src/controllers/notificationsController.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import Notification from "../models/Notification.js";

--- a/backend/src/controllers/profilePictureController.js
+++ b/backend/src/controllers/profilePictureController.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import User from "../models/User.js";

--- a/backend/src/controllers/projectsController.js
+++ b/backend/src/controllers/projectsController.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import Project from "../models/Project.js";

--- a/backend/src/controllers/reviewController.js
+++ b/backend/src/controllers/reviewController.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import ReviewAssignment from "../models/ReviewAssignment.js";

--- a/backend/src/controllers/systemController.js
+++ b/backend/src/controllers/systemController.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import os from 'os';

--- a/backend/src/controllers/teamsController.js
+++ b/backend/src/controllers/teamsController.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import Team from "../models/Team.js";

--- a/backend/src/controllers/uploadFileController.js
+++ b/backend/src/controllers/uploadFileController.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import File from "../models/File.js";  // Your file schema/model

--- a/backend/src/controllers/usersController.js
+++ b/backend/src/controllers/usersController.js
@@ -104,3 +104,60 @@ export async function deleteUser(req, res) {
         });
     }
 }
+
+/**
+ * Get users that are not yet linked to Authentik.
+ * @param {Object} req - Express request object
+ * @param {Object} res - Express response object
+ * @returns {Object} JSON response with unlinked users
+ */
+export async function getUsersMissingAuthentikLink(req, res) {
+    try {
+        const limit = Number.parseInt(req.query.limit, 10) || 500;
+        const users = await userService.getUsersMissingAuthentikLink({ limit });
+        res.status(200).json({
+            total: users.length,
+            users,
+        });
+    } catch (error) {
+        console.error("Error fetching unlinked Authentik users:", error);
+        res.status(500).json({
+            message: error.message || "Failed to retrieve unlinked users",
+        });
+    }
+}
+
+/**
+ * Link a local RDocMan user to an Authentik subject.
+ * @param {Object} req - Express request object
+ * @param {Object} res - Express response object
+ * @returns {Object} JSON response with linking result
+ */
+export async function linkUserToAuthentikIdentity(req, res) {
+    try {
+        const { userId, email, username, authentikSub, force } = req.body || {};
+        const result = await userService.linkUserToAuthentikIdentity({
+            userId,
+            email,
+            username,
+            authentikSub,
+            force: Boolean(force),
+        });
+
+        res.status(200).json({
+            message: "User linked to Authentik successfully",
+            user: result,
+        });
+    } catch (error) {
+        console.error("Error linking user to Authentik:", error);
+        const statusCode = error.message.includes("required") ? 400
+            : error.message.includes("already linked") ? 409
+            : error.message.includes("already linked to another user") ? 409
+            : error.message.includes("not found") ? 404
+            : 500;
+
+        res.status(statusCode).json({
+            message: error.message || "Failed to link user to Authentik",
+        });
+    }
+}

--- a/backend/src/controllers/usersController.js
+++ b/backend/src/controllers/usersController.js
@@ -4,7 +4,7 @@
  * @controller usersController
  * @description User management controller for CRUD operations, profile updates, and user administration
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import bcrypt from "bcrypt";

--- a/backend/src/lib/emailService.js
+++ b/backend/src/lib/emailService.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { SESClient, SendEmailCommand } from "@aws-sdk/client-ses";

--- a/backend/src/lib/errorHandler.js
+++ b/backend/src/lib/errorHandler.js
@@ -4,7 +4,7 @@
  * @module errorHandler
  * @description Standardized error handling and logging utilities for consistent error management
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import fs from 'fs';

--- a/backend/src/lib/globalUtils.js
+++ b/backend/src/lib/globalUtils.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 // backend/src/lib/globalUtils.js

--- a/backend/src/lib/jwtSecret.js
+++ b/backend/src/lib/jwtSecret.js
@@ -4,7 +4,7 @@
  * @module jwtSecret
  * @description Shared JWT secret configuration for token signing and verification
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import dotenv from "dotenv";

--- a/backend/src/lib/secretToken.js
+++ b/backend/src/lib/secretToken.js
@@ -4,7 +4,7 @@
  * @module secretToken
  * @description JWT token utilities for creating, verifying, and blacklisting authentication tokens
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import jwt from "jsonwebtoken";

--- a/backend/src/lib/secretToken.js
+++ b/backend/src/lib/secretToken.js
@@ -8,9 +8,9 @@
  * @license UNLICENSED
  */
 import jwt from "jsonwebtoken";
-import User from "../models/User.js";
 import BlacklistedToken from "../models/BlacklistedToken.js";
 import { TOKEN_KEY } from "./jwtSecret.js";
+import { extractBearerToken, resolveRequestIdentity } from "../services/identityService.js";
 
 /**
  * Create an access token for API authentication
@@ -56,11 +56,10 @@ export function createSecretToken(id, role) {
  */
 export async function verifyAccessToken(req, res, next) {
     try {
-        const authHeader = req.headers?.authorization || "";
-        const token = authHeader.startsWith("Bearer ") ? authHeader.split(" ")[1] : null;
+        const token = extractBearerToken(req);
 
         console.log("🔒 verifyAccessToken: Processing request to:", req.url);
-        console.log("🔒 verifyAccessToken: Auth header:", authHeader ? "present" : "missing");
+        console.log("🔒 verifyAccessToken: Auth header:", req.headers?.authorization ? "present" : "missing");
         console.log("🔒 verifyAccessToken: Token:", token ? token.substring(0, 20) + "..." : "none");
 
         if (!token) {
@@ -68,15 +67,6 @@ export async function verifyAccessToken(req, res, next) {
             return res.status(401).json({ message: "No token provided" });
         }
 
-        // Check if token is blacklisted
-        const blacklistedToken = await BlacklistedToken.findOne({ token });
-        if (blacklistedToken) {
-            return res.status(401).json({ message: "Token has been invalidated" });
-        }
-
-        console.log("🔒 verifyAccessToken: Attempting to verify token with secret length:", TOKEN_KEY.length);
-
-        // First decode without verification to check expiration
         const decodedWithoutVerify = jwt.decode(token);
         const now = Math.floor(Date.now() / 1000);
         const timeUntilExpiry = decodedWithoutVerify?.exp - now;
@@ -87,34 +77,16 @@ export async function verifyAccessToken(req, res, next) {
             expired: timeUntilExpiry <= 0
         });
 
-        const decoded = jwt.verify(token, TOKEN_KEY);
-        console.log("🔒 verifyAccessToken: Token decoded successfully:", { id: decoded?.id, role: decoded?.role });
-
-        if (!decoded || !decoded.id) {
-            console.log("🔒 Invalid token structure:", { decoded: !!decoded, hasId: !!decoded?.id });
-            return res.status(401).json({ message: "Invalid token" });
-        }
-
-        // Attach minimal user info (id and role). If you need full user object, fetch from DB.
-        // Here we fetch role from DB to ensure latest role change is respected.
-        console.log("🔒 verifyAccessToken: Looking up user with ID:", decoded.id);
-        const user = await User.findById(decoded.id).select("-password -refreshTokenHash -resetPasswordToken -resetPasswordExpires").lean();
-        console.log("🔒 verifyAccessToken: User found:", !!user, user ? `(${user.email})` : "none");
-
-        if (!user) {
-            console.log("🔒 verifyAccessToken: User not found in database");
-            return res.status(401).json({ message: "User not found" });
-        }
-
-        // Ensure user object has id field for compatibility
-        user.id = user._id.toString();
-        req.user = user;
-        console.log("🔒 verifyAccessToken: Success! User attached to request:", user.email);
+        const identity = await resolveRequestIdentity(req);
+        req.user = identity.user;
+        req.identity = identity;
+        console.log("🔒 verifyAccessToken: Identity resolved via:", identity.authType);
+        console.log("🔒 verifyAccessToken: Success! User attached to request:", identity.user.email);
         next();
     } catch (err) {
         console.error("🔒 verifyAccessToken error:", err.message || err);
         console.error("🔒 Token verification failed. TOKEN_KEY length:", TOKEN_KEY.length);
-        return res.status(401).json({ message: "Invalid token" });
+        return res.status(err.statusCode || 401).json({ message: err.message || "Invalid token" });
     }
 }
 

--- a/backend/src/lib/sharedValidation.js
+++ b/backend/src/lib/sharedValidation.js
@@ -4,7 +4,7 @@
  * @module sharedValidation
  * @description Shared validation utilities for consistent validation across all services
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import validator from 'validator';

--- a/backend/src/lib/utils.js
+++ b/backend/src/lib/utils.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 /**

--- a/backend/src/lib/validation.js
+++ b/backend/src/lib/validation.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 // Server-side validation utilities

--- a/backend/src/middleware/authMid.js
+++ b/backend/src/middleware/authMid.js
@@ -4,7 +4,7 @@
  * @middleware authMid
  * @description JWT authentication middleware for verifying Bearer tokens and protecting routes
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import jwt from "jsonwebtoken";

--- a/backend/src/middleware/authRateLimiter.js
+++ b/backend/src/middleware/authRateLimiter.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { Ratelimit } from "@upstash/ratelimit";

--- a/backend/src/middleware/cacheMiddleware.js
+++ b/backend/src/middleware/cacheMiddleware.js
@@ -4,7 +4,7 @@
  * @middleware cacheMiddleware
  * @description Caching middleware for API responses to improve performance
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 

--- a/backend/src/middleware/inputValidation.js
+++ b/backend/src/middleware/inputValidation.js
@@ -4,7 +4,7 @@
  * @middleware inputValidation
  * @description Centralized input validation middleware for sanitizing and validating all user inputs
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import validator from 'validator';

--- a/backend/src/middleware/performanceMonitor.js
+++ b/backend/src/middleware/performanceMonitor.js
@@ -4,7 +4,7 @@
  * @middleware performanceMonitor
  * @description Performance monitoring middleware for tracking API response times and database query performance
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 

--- a/backend/src/middleware/rateLimiter.js
+++ b/backend/src/middleware/rateLimiter.js
@@ -4,7 +4,7 @@
  * @middleware rateLimiter
  * @description Rate limiting middleware using Redis for preventing API abuse and ensuring fair usage
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import ratelimit from "../config/upstash.js";

--- a/backend/src/middleware/requireRole.js
+++ b/backend/src/middleware/requireRole.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 // middleware/requireRole.js

--- a/backend/src/middleware/securityHeaders.js
+++ b/backend/src/middleware/securityHeaders.js
@@ -4,7 +4,7 @@
  * @middleware securityHeaders
  * @description Comprehensive security headers middleware for protecting against common web vulnerabilities
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 

--- a/backend/src/middleware/uploadMid.js
+++ b/backend/src/middleware/uploadMid.js
@@ -4,7 +4,7 @@
  * @middleware uploadMid
  * @description File upload middleware for handling multipart form data and file validation
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import multer from "multer";

--- a/backend/src/models/BlacklistedToken.js
+++ b/backend/src/models/BlacklistedToken.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from "mongoose";

--- a/backend/src/models/Book.js
+++ b/backend/src/models/Book.js
@@ -4,7 +4,7 @@
  * @model Book
  * @description Book model schema for organizing documents into collections within teams and projects
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from "mongoose";

--- a/backend/src/models/Category.js
+++ b/backend/src/models/Category.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 // backend/src/models/Category.js

--- a/backend/src/models/CustomChart.js
+++ b/backend/src/models/CustomChart.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from "mongoose";

--- a/backend/src/models/Doc.js
+++ b/backend/src/models/Doc.js
@@ -4,7 +4,7 @@
  * @model Doc
  * @description Document model schema for managing document metadata, version history, stakeholders, and review workflows
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 // backend/src/models/Doc.js

--- a/backend/src/models/ExternalContact.js
+++ b/backend/src/models/ExternalContact.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from "mongoose";

--- a/backend/src/models/ExternalContactType.js
+++ b/backend/src/models/ExternalContactType.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from "mongoose";

--- a/backend/src/models/File.js
+++ b/backend/src/models/File.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from "mongoose";

--- a/backend/src/models/Notification.js
+++ b/backend/src/models/Notification.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 // backend/src/models/Notification.js

--- a/backend/src/models/Project.js
+++ b/backend/src/models/Project.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 // backend/src/models/Project.js

--- a/backend/src/models/ReviewAssignment.js
+++ b/backend/src/models/ReviewAssignment.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from "mongoose";

--- a/backend/src/models/Team.js
+++ b/backend/src/models/Team.js
@@ -4,7 +4,7 @@
  * @model Team
  * @description Team model schema for collaborative team management with members, invitations, and project associations
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 // backend/src/models/Team.js

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -29,6 +29,8 @@ import bcrypt from "bcrypt";
  * @property {string} resetPasswordToken - Token for password reset (optional)
  * @property {Date} resetPasswordExpires - Expiration date for password reset token (optional)
  * @property {string} refreshTokenHash - Hashed refresh token for authentication (optional)
+ * @property {string} identityProvider - Identity source for this user record (default: local)
+ * @property {string} authentikSub - External Authentik subject identifier for suite SSO linking (optional)
  * @property {ObjectId} lastUpdatedBy - ID of user who last updated this record (optional)
  * @property {Date} createdAt - Timestamp when user was created (auto-generated)
  * @property {Date} updatedAt - Timestamp when user was last updated (auto-generated)
@@ -95,6 +97,16 @@ const userSchema = new mongoose.Schema(
         resetPasswordToken: String,
         resetPasswordExpires: Date,
         refreshTokenHash: { type: String },
+        identityProvider: {
+            type: String,
+            enum: ["local", "authentik"],
+            default: "local",
+        },
+        authentikSub: {
+            type: String,
+            required: false,
+            trim: true,
+        },
         lastUpdatedBy: {
             type: mongoose.Schema.Types.ObjectId,
             ref: 'User',
@@ -115,6 +127,8 @@ userSchema.pre("save", async function(next) {
     }
     next();
 });
+
+userSchema.index({ authentikSub: 1 }, { unique: true, sparse: true });
 
 /**
  * User model for managing user accounts and authentication

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -4,7 +4,7 @@
  * @model User
  * @description User model schema for authentication, profile management, and role-based access control
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from "mongoose";

--- a/backend/src/routes/analyticsRoutes.js
+++ b/backend/src/routes/analyticsRoutes.js
@@ -4,7 +4,7 @@
  * @routes analyticsRoutes
  * @description Analytics routes for generating reports, metrics, and data visualizations
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/authRoutes.js
+++ b/backend/src/routes/authRoutes.js
@@ -8,8 +8,9 @@
  * @license UNLICENSED
  */
 import express from "express";
-import { register, login, forgotPassword, resetPassword, refreshToken, logout } from "../controllers/authController.js";
+import { register, login, forgotPassword, resetPassword, refreshToken, logout, getCurrentSession } from "../controllers/authController.js";
 import { limitLogin, limitRegister, limitPasswordReset } from "../middleware/authRateLimiter.js";
+import { verifyAccessToken } from "../lib/secretToken.js";
 
 const router = express.Router();
 
@@ -165,5 +166,8 @@ router.get("/refresh", refreshToken);
 
 // POST /api/auth/logout - Invalidate a user's refresh token and clear authentication cookies
 router.post("/logout", logout);
+
+// GET /api/auth/me - Return the current authenticated session user
+router.get("/me", verifyAccessToken, getCurrentSession);
 
 export default router;

--- a/backend/src/routes/authRoutes.js
+++ b/backend/src/routes/authRoutes.js
@@ -4,7 +4,7 @@
  * @routes authRoutes
  * @description Authentication routes for user registration, login, logout, password reset, and token refresh
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/booksRoutes.js
+++ b/backend/src/routes/booksRoutes.js
@@ -4,7 +4,7 @@
  * @routes booksRoutes
  * @description Book management routes for organizing documents into collections
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/categoriesRoutes.js
+++ b/backend/src/routes/categoriesRoutes.js
@@ -4,7 +4,7 @@
  * @routes categoriesRoutes
  * @description Category management routes for organizing and managing document categories
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/customChartsRoutes.js
+++ b/backend/src/routes/customChartsRoutes.js
@@ -4,7 +4,7 @@
  * @routes customChartsRoutes
  * @description Custom chart routes for creating and managing personalized analytics
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/docsRoutes.js
+++ b/backend/src/routes/docsRoutes.js
@@ -4,7 +4,7 @@
  * @routes docsRoutes
  * @description Document management routes for CRUD operations, file uploads, version control, and review workflows
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/externalContactsRoutes.js
+++ b/backend/src/routes/externalContactsRoutes.js
@@ -4,7 +4,7 @@
  * @routes externalContactsRoutes
  * @description External contact management routes for stakeholder organization
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/notificationsRoutes.js
+++ b/backend/src/routes/notificationsRoutes.js
@@ -4,7 +4,7 @@
  * @routes notificationsRoutes
  * @description Notification routes for managing user notifications and alerts
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/projectsRoutes.js
+++ b/backend/src/routes/projectsRoutes.js
@@ -4,7 +4,7 @@
  * @routes projectsRoutes
  * @description Project management routes for project operations and team assignments
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/reviewRoutes.js
+++ b/backend/src/routes/reviewRoutes.js
@@ -4,7 +4,7 @@
  * @routes reviewRoutes
  * @description Document review routes for managing review workflows and approvals
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/systemRoutes.js
+++ b/backend/src/routes/systemRoutes.js
@@ -4,7 +4,7 @@
  * @routes systemRoutes
  * @description System information routes for health checks, status monitoring, and diagnostics
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/teamsRoutes.js
+++ b/backend/src/routes/teamsRoutes.js
@@ -4,7 +4,7 @@
  * @routes teamsRoutes
  * @description Team management routes for team operations, member management, and collaboration
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/uploadRoutes.js
+++ b/backend/src/routes/uploadRoutes.js
@@ -4,7 +4,7 @@
  * @routes uploadRoutes
  * @description File upload routes for handling document uploads and file management
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/usersRoutes.js
+++ b/backend/src/routes/usersRoutes.js
@@ -4,7 +4,7 @@
  * @routes usersRoutes
  * @description User management routes for CRUD operations, profile updates, and administrative functions
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/usersRoutes.js
+++ b/backend/src/routes/usersRoutes.js
@@ -11,7 +11,14 @@ import express from "express";
 import { verifyAccessToken } from "../lib/secretToken.js";
 import { requireRole } from "../middleware/requireRole.js";
 import uploadMid from "../middleware/uploadMid.js";
-import { getAllUsers, getUserById, updateUser, deleteUser } from "../controllers/usersController.js";
+import {
+    getAllUsers,
+    getUserById,
+    updateUser,
+    deleteUser,
+    getUsersMissingAuthentikLink,
+    linkUserToAuthentikIdentity,
+} from "../controllers/usersController.js";
 import { uploadProfilePicture, deleteProfilePicture, uploadBackgroundImage, deleteBackgroundImage } from "../controllers/profilePictureController.js";
 
 /**
@@ -24,6 +31,12 @@ const router = express.Router();
 
 // GET /api/users - Get all users (viewers and above can view users)
 router.get("/", verifyAccessToken, requireRole("viewer"), getAllUsers);
+
+// GET /api/users/authentik/unlinked - Get users missing Authentik links (admin and superadmin only)
+router.get("/authentik/unlinked", verifyAccessToken, requireRole("admin", "superadmin"), getUsersMissingAuthentikLink);
+
+// POST /api/users/authentik/link - Link a local user to an Authentik subject (superadmin only)
+router.post("/authentik/link", verifyAccessToken, requireRole("superadmin"), linkUserToAuthentikIdentity);
 
 // GET /api/users/:id - Get specific user by ID (for profile editing)
 router.get("/:id", verifyAccessToken, requireRole("viewer"), getUserById);

--- a/backend/src/scripts/clearData/clearAllCollections.js
+++ b/backend/src/scripts/clearData/clearAllCollections.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearAllCollections.js
  * @description Script to clear all collections from the database
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearBlacklistedTokens.js
+++ b/backend/src/scripts/clearData/clearBlacklistedTokens.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearBlacklistedTokens.js
  * @description Script to clear all blacklisted tokens from the database
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearBooks.js
+++ b/backend/src/scripts/clearData/clearBooks.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearBooks.js
  * @description Script to clear all books from the database
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearCategories.js
+++ b/backend/src/scripts/clearData/clearCategories.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearCategories.js
  * @description Script to clear all categories from the database
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearCustomCharts.js
+++ b/backend/src/scripts/clearData/clearCustomCharts.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearCustomCharts.js
  * @description Script to clear all custom charts from the database
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearDocs.js
+++ b/backend/src/scripts/clearData/clearDocs.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearDocs.js
  * @description Script to clear all documents from the database
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearExternalContactTypes.js
+++ b/backend/src/scripts/clearData/clearExternalContactTypes.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearExternalContactTypes.js
  * @description Script to clear all external contact types from the database
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearExternalContacts.js
+++ b/backend/src/scripts/clearData/clearExternalContacts.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearExternalContacts.js
  * @description Script to clear all external contacts from the database
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearFiles.js
+++ b/backend/src/scripts/clearData/clearFiles.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearFiles.js
  * @description Script to clear all files from the database
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearNotifications.js
+++ b/backend/src/scripts/clearData/clearNotifications.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearNotifications.js
  * @description Script to clear all notifications from the database
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearProjects.js
+++ b/backend/src/scripts/clearData/clearProjects.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearProjects.js
  * @description Script to clear all projects from the database
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearReviewAssignments.js
+++ b/backend/src/scripts/clearData/clearReviewAssignments.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearReviewAssignments.js
  * @description Script to clear all review assignments from the database
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearTeams.js
+++ b/backend/src/scripts/clearData/clearTeams.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearTeams.js
  * @description Script to clear all teams from the database
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearUsers.js
+++ b/backend/src/scripts/clearData/clearUsers.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearUsers.js
  * @description Script to clear all users from the database
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/createBookCategory.js
+++ b/backend/src/scripts/createBookCategory.js
@@ -4,7 +4,7 @@
  * @script createBookCategory
  * @description Script to create a sample Book category for testing
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 

--- a/backend/src/scripts/dummyData/createAllDummyData.js
+++ b/backend/src/scripts/dummyData/createAllDummyData.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createAllDummyData.js
  * @description Script to create dummy data for all collections in the database
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyBlacklistedTokens.js
+++ b/backend/src/scripts/dummyData/createDummyBlacklistedTokens.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyBlacklistedTokens.js
  * @description Script to create dummy blacklisted tokens in the database
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyBooks.js
+++ b/backend/src/scripts/dummyData/createDummyBooks.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyBooks.js
  * @description Script to create dummy books in the database
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyCategories.js
+++ b/backend/src/scripts/dummyData/createDummyCategories.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyCategories.js
  * @description Script to create dummy categories in the database
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyCustomCharts.js
+++ b/backend/src/scripts/dummyData/createDummyCustomCharts.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyCustomCharts.js
  * @description Script to create dummy custom charts in the database
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyDocs.js
+++ b/backend/src/scripts/dummyData/createDummyDocs.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyDocs.js
  * @description Script to create dummy documents in the database
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyExternalContactTypes.js
+++ b/backend/src/scripts/dummyData/createDummyExternalContactTypes.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyExternalContactTypes.js
  * @description Script to create dummy external contact types in the database
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyExternalContacts.js
+++ b/backend/src/scripts/dummyData/createDummyExternalContacts.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyExternalContacts.js
  * @description Script to create dummy external contacts in the database
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyFiles.js
+++ b/backend/src/scripts/dummyData/createDummyFiles.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyFiles.js
  * @description Script to create dummy file records in the database
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyNotifications.js
+++ b/backend/src/scripts/dummyData/createDummyNotifications.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyNotifications.js
  * @description Script to create dummy notifications in the database
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyProjects.js
+++ b/backend/src/scripts/dummyData/createDummyProjects.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyProjects.js
  * @description Script to create dummy projects in the database
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyReviewAssignments.js
+++ b/backend/src/scripts/dummyData/createDummyReviewAssignments.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyReviewAssignments.js
  * @description Script to create dummy review assignments in the database
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyTeams.js
+++ b/backend/src/scripts/dummyData/createDummyTeams.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyTeams.js
  * @description Script to create dummy teams in the database
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyUsers.js
+++ b/backend/src/scripts/dummyData/createDummyUsers.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyUsers.js
  * @description Script to create dummy users in the database
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/linkAuthentikUsers.js
+++ b/backend/src/scripts/linkAuthentikUsers.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/linkAuthentikUsers.js
  * @description Bulk link existing DocMan users to Authentik subject IDs through an explicit mapping file
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import fs from "fs";

--- a/backend/src/scripts/linkAuthentikUsers.js
+++ b/backend/src/scripts/linkAuthentikUsers.js
@@ -1,0 +1,188 @@
+/*
+ * @name linkAuthentikUsers
+ * @file /docman/backend/src/scripts/linkAuthentikUsers.js
+ * @description Bulk link existing DocMan users to Authentik subject IDs through an explicit mapping file
+ * @author Richard Bakos
+ * @version 2.2.3
+ * @license UNLICENSED
+ */
+import fs from "fs";
+import path from "path";
+import dotenv from "dotenv";
+import mongoose from "mongoose";
+import { fileURLToPath } from "url";
+import { connectDB } from "../config/db.js";
+import {
+    getUsersMissingAuthentikLink,
+    linkUserToAuthentikIdentity,
+} from "../services/userService.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const backendRoot = path.resolve(__dirname, "..", "..");
+
+if (process.env.NODE_ENV === "development") {
+    dotenv.config({ path: path.join(backendRoot, ".env.dev") });
+} else if (process.env.NODE_ENV === "production") {
+    dotenv.config({ path: path.join(backendRoot, ".env.prod") });
+} else {
+    dotenv.config({ path: path.join(backendRoot, ".env") });
+}
+
+function parseArgs(argv) {
+    const parsed = {
+        dryRun: false,
+        force: false,
+        reportUnlinked: false,
+        mapping: "",
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const arg = argv[index];
+        switch (arg) {
+            case "--dry-run":
+                parsed.dryRun = true;
+                break;
+            case "--force":
+                parsed.force = true;
+                break;
+            case "--report-unlinked":
+                parsed.reportUnlinked = true;
+                break;
+            case "--mapping":
+                parsed.mapping = argv[index + 1] || "";
+                index += 1;
+                break;
+            default:
+                throw new Error(`Unknown argument: ${arg}`);
+        }
+    }
+
+    return parsed;
+}
+
+function printUsage() {
+    console.log(`
+Usage:
+  node src/scripts/linkAuthentikUsers.js --report-unlinked
+  node src/scripts/linkAuthentikUsers.js --mapping path/to/authentik-links.json [--dry-run] [--force]
+
+Mapping file format:
+[
+  {
+    "email": "user@example.com",
+    "authentikSub": "authentik-subject-id"
+  },
+  {
+    "username": "jdoe",
+    "authentikSub": "another-subject-id"
+  },
+  {
+    "userId": "680c5d7f2d4f9d0f7b8f1111",
+    "authentikSub": "third-subject-id"
+  }
+]
+    `.trim());
+}
+
+function resolveMappingFile(filePath) {
+    if (!filePath) {
+        throw new Error("A mapping file path is required when not using --report-unlinked");
+    }
+
+    return path.isAbsolute(filePath)
+        ? filePath
+        : path.resolve(process.cwd(), filePath);
+}
+
+function loadMappings(mappingPath) {
+    const content = fs.readFileSync(mappingPath, "utf8");
+    const mappings = JSON.parse(content);
+    if (!Array.isArray(mappings)) {
+        throw new Error("Mapping file must contain a JSON array");
+    }
+
+    return mappings;
+}
+
+async function reportUnlinkedUsers() {
+    const users = await getUsersMissingAuthentikLink();
+    console.log(JSON.stringify({
+        total: users.length,
+        users,
+    }, null, 2));
+}
+
+async function runLinking({ mappings, dryRun, force }) {
+    const summary = {
+        total: mappings.length,
+        linked: [],
+        failed: [],
+    };
+
+    for (const mapping of mappings) {
+        const target = {
+            userId: mapping.userId,
+            email: mapping.email,
+            username: mapping.username,
+            authentikSub: mapping.authentikSub,
+            force,
+        };
+
+        try {
+            if (dryRun) {
+                summary.linked.push({
+                    mode: "dry-run",
+                    ...target,
+                });
+                continue;
+            }
+
+            const result = await linkUserToAuthentikIdentity(target);
+            summary.linked.push(result);
+        } catch (error) {
+            summary.failed.push({
+                ...target,
+                error: error.message,
+            });
+        }
+    }
+
+    console.log(JSON.stringify(summary, null, 2));
+
+    if (summary.failed.length > 0) {
+        process.exitCode = 1;
+    }
+}
+
+async function main() {
+    const options = parseArgs(process.argv.slice(2));
+    if (!options.reportUnlinked && !options.mapping) {
+        printUsage();
+        throw new Error("Either --report-unlinked or --mapping must be provided");
+    }
+
+    await connectDB();
+
+    if (options.reportUnlinked) {
+        await reportUnlinkedUsers();
+        return;
+    }
+
+    const mappingPath = resolveMappingFile(options.mapping);
+    const mappings = loadMappings(mappingPath);
+    await runLinking({
+        mappings,
+        dryRun: options.dryRun,
+        force: options.force,
+    });
+}
+
+main()
+    .catch((error) => {
+        console.error("❌ Authentik linking failed:", error.message || error);
+        process.exitCode = 1;
+    })
+    .finally(async () => {
+        await mongoose.connection.close();
+    });

--- a/backend/src/scripts/migrateCategoryTypes.js
+++ b/backend/src/scripts/migrateCategoryTypes.js
@@ -4,7 +4,7 @@
  * @script migrateCategoryTypes
  * @description Migration script to add type field to existing categories
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 

--- a/backend/src/scripts/migrateReviewFields.js
+++ b/backend/src/scripts/migrateReviewFields.js
@@ -4,7 +4,7 @@
  * @script migrateReviewFields
  * @description Migration script to update documents from old reviewDate field to new review system
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from "mongoose";

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/server.js
  * @description Main entry point of the DocMan backend application
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { connectDB } from "./config/db.js";

--- a/backend/src/services/documentService.js
+++ b/backend/src/services/documentService.js
@@ -4,7 +4,7 @@
  * @service documentService
  * @description Business logic service for document operations including CRUD, validation, and access control
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from "mongoose";

--- a/backend/src/services/identityService.js
+++ b/backend/src/services/identityService.js
@@ -1,0 +1,172 @@
+/*
+ * @name identityService
+ * @file /docman/backend/src/services/identityService.js
+ * @service identityService
+ * @description Transitional identity resolution service for local JWT auth today and shared suite identity providers later
+ * @author Richard Bakos
+ * @version 2.2.3
+ * @license UNLICENSED
+ */
+import jwt from "jsonwebtoken";
+import User from "../models/User.js";
+import BlacklistedToken from "../models/BlacklistedToken.js";
+import { TOKEN_KEY } from "../lib/jwtSecret.js";
+
+const USER_SELECT_FIELDS = "-password -refreshTokenHash -resetPasswordToken -resetPasswordExpires";
+const AUTHENTIK_ISSUER = process.env.AUTHENTIK_ISSUER || process.env.AUTHENTIK_BASE_URL || "";
+const AUTHENTIK_AUDIENCE = process.env.AUTHENTIK_AUDIENCE || process.env.AUTHENTIK_CLIENT_ID || "";
+const AUTHENTIK_JWT_PUBLIC_KEY = normalizePem(process.env.AUTHENTIK_JWT_PUBLIC_KEY || "");
+
+function createAuthError(message, statusCode = 401) {
+    const error = new Error(message);
+    error.statusCode = statusCode;
+    return error;
+}
+
+function normalizePem(value) {
+    return value ? value.replace(/\\n/g, "\n").trim() : "";
+}
+
+function isAuthentikConfigured() {
+    return Boolean(AUTHENTIK_ISSUER && AUTHENTIK_AUDIENCE && AUTHENTIK_JWT_PUBLIC_KEY);
+}
+
+function isAuthentikToken(decoded) {
+    if (!decoded || typeof decoded !== "object") {
+        return false;
+    }
+
+    return Boolean(AUTHENTIK_ISSUER && decoded.iss === AUTHENTIK_ISSUER);
+}
+
+/**
+ * Extract a Bearer token from the request Authorization header.
+ * @param {Object} req - Express request object
+ * @returns {string|null} Extracted Bearer token or null
+ */
+export function extractBearerToken(req) {
+    const authHeader = req.headers?.authorization || "";
+    if (!authHeader.startsWith("Bearer ")) {
+        return null;
+    }
+
+    return authHeader.split(" ")[1];
+}
+
+/**
+ * Normalize a user document into the request identity shape expected by the rest of the app.
+ * @param {Object} user - User document or lean object
+ * @returns {Object} Normalized request user object
+ */
+export function normalizeRequestUser(user) {
+    if (!user) {
+        return null;
+    }
+
+    const normalizedUser = { ...user };
+    normalizedUser.id = normalizedUser._id.toString();
+
+    return normalizedUser;
+}
+
+/**
+ * Resolve an application user by Authentik subject.
+ * @param {string} authentikSub - Authentik subject claim
+ * @returns {Promise<Object|null>} Normalized request user or null
+ */
+export async function findUserByAuthentikSub(authentikSub) {
+    if (!authentikSub) {
+        return null;
+    }
+
+    const user = await User.findOne({ authentikSub }).select(USER_SELECT_FIELDS).lean();
+    return normalizeRequestUser(user);
+}
+
+/**
+ * Resolve the current local DocMan JWT identity.
+ * This is the current authentication path and remains in place while the app is prepared for Authentik.
+ * @param {string} token - Bearer token supplied by the client
+ * @returns {Promise<Object>} Normalized identity context
+ */
+export async function resolveLocalTokenIdentity(token) {
+    if (!token) {
+        throw createAuthError("No token provided");
+    }
+
+    const blacklistedToken = await BlacklistedToken.findOne({ token }).lean();
+    if (blacklistedToken) {
+        throw createAuthError("Token has been invalidated");
+    }
+
+    const decoded = jwt.verify(token, TOKEN_KEY);
+    if (!decoded?.id) {
+        throw createAuthError("Invalid token");
+    }
+
+    const user = await User.findById(decoded.id).select(USER_SELECT_FIELDS).lean();
+    if (!user) {
+        throw createAuthError("User not found");
+    }
+
+    return {
+        authType: "local-jwt",
+        provider: user.identityProvider || "local",
+        tokenClaims: decoded,
+        user: normalizeRequestUser(user),
+    };
+}
+
+/**
+ * Resolve a request authenticated through Authentik-issued JWTs.
+ * @param {string} token - Bearer token supplied by the client
+ * @returns {Promise<Object>} Normalized identity context
+ */
+export async function resolveAuthentikTokenIdentity(token) {
+    if (!isAuthentikConfigured()) {
+        throw createAuthError("Authentik identity is not configured", 500);
+    }
+
+    const decoded = jwt.verify(token, AUTHENTIK_JWT_PUBLIC_KEY, {
+        algorithms: ["RS256"],
+        issuer: AUTHENTIK_ISSUER,
+        audience: AUTHENTIK_AUDIENCE,
+    });
+
+    if (!decoded?.sub) {
+        throw createAuthError("Invalid Authentik token");
+    }
+
+    const user = await findUserByAuthentikSub(decoded.sub);
+    if (!user) {
+        throw createAuthError("No linked RDocMan user for Authentik identity");
+    }
+
+    return {
+        authType: "authentik-jwt",
+        provider: "authentik",
+        tokenClaims: decoded,
+        user,
+    };
+}
+
+/**
+ * Resolve request identity.
+ * Today this supports DocMan-local JWT access tokens.
+ * Later this is the seam where Authentik token validation and external subject mapping should be added.
+ * @param {Object} req - Express request object
+ * @returns {Promise<Object>} Identity context with user and token claims
+ */
+export async function resolveRequestIdentity(req) {
+    const token = extractBearerToken(req);
+    if (!token) {
+        throw createAuthError("No token provided");
+    }
+
+    const decoded = jwt.decode(token);
+    if (isAuthentikToken(decoded)) {
+        return resolveAuthentikTokenIdentity(token);
+    }
+
+    return resolveLocalTokenIdentity(token);
+}

--- a/backend/src/services/identityService.js
+++ b/backend/src/services/identityService.js
@@ -4,7 +4,7 @@
  * @service identityService
  * @description Transitional identity resolution service for local JWT auth today and shared suite identity providers later
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import jwt from "jsonwebtoken";

--- a/backend/src/services/queryOptimizationService.js
+++ b/backend/src/services/queryOptimizationService.js
@@ -4,7 +4,7 @@
  * @service queryOptimizationService
  * @description Optimized database queries with caching and performance monitoring
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/services/userService.js
+++ b/backend/src/services/userService.js
@@ -4,7 +4,7 @@
  * @service userService
  * @description Business logic service for user operations including CRUD, validation, and access control
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import User from "../models/User.js";

--- a/backend/src/services/userService.js
+++ b/backend/src/services/userService.js
@@ -371,3 +371,100 @@ export async function deleteUser(userId, requestingUser) {
         throw new Error(sanitizeErrorMessage(error, "Failed to delete user"));
     }
 }
+
+/**
+ * Get users that have not yet been linked to an Authentik identity.
+ * @param {Object} options - Query options
+ * @param {number} options.limit - Maximum number of users to return
+ * @returns {Promise<Array>} Unlinked user records
+ */
+export async function getUsersMissingAuthentikLink({ limit = 500 } = {}) {
+    try {
+        return await User.find({
+            $or: [
+                { authentikSub: { $exists: false } },
+                { authentikSub: null },
+                { authentikSub: "" },
+            ],
+        })
+            .select("_id firstname lastname email username role identityProvider authentikSub")
+            .sort({ email: 1 })
+            .limit(Math.max(1, Math.min(limit, 5000)))
+            .lean();
+    } catch (error) {
+        logError("getUsersMissingAuthentikLink", error);
+        throw new Error(sanitizeErrorMessage(error, "Failed to retrieve unlinked users"));
+    }
+}
+
+/**
+ * Link a local RDocMan user to an Authentik subject.
+ * @param {Object} params - Linking parameters
+ * @param {string} [params.userId] - Local user ID
+ * @param {string} [params.email] - Local user email lookup
+ * @param {string} [params.username] - Local user username lookup
+ * @param {string} params.authentikSub - Authentik subject to link
+ * @param {boolean} [params.force=false] - Allow replacing an existing Authentik link
+ * @returns {Promise<Object>} Link result summary
+ */
+export async function linkUserToAuthentikIdentity({
+    userId,
+    email,
+    username,
+    authentikSub,
+    force = false,
+}) {
+    try {
+        if (!authentikSub || typeof authentikSub !== "string") {
+            throw new Error("authentikSub is required");
+        }
+
+        const normalizedSub = authentikSub.trim();
+        if (!normalizedSub) {
+            throw new Error("authentikSub is required");
+        }
+
+        const lookup = [];
+        if (userId) lookup.push({ _id: userId });
+        if (email) lookup.push({ email: sanitizeEmail(email) });
+        if (username) lookup.push({ username: sanitizeString(username) });
+
+        if (lookup.length === 0) {
+            throw new Error("A user lookup field is required: userId, email, or username");
+        }
+
+        const user = await User.findOne(lookup.length === 1 ? lookup[0] : { $or: lookup });
+        if (!user) {
+            throw new Error("User not found");
+        }
+
+        if (user.authentikSub && user.authentikSub !== normalizedSub && !force) {
+            throw new Error(`User already linked to Authentik subject ${user.authentikSub}`);
+        }
+
+        const existingLinkedUser = await User.findOne({
+            authentikSub: normalizedSub,
+            _id: { $ne: user._id },
+        }).select("_id email username authentikSub");
+
+        if (existingLinkedUser) {
+            throw new Error(`Authentik subject ${normalizedSub} is already linked to another user`);
+        }
+
+        user.identityProvider = "authentik";
+        user.authentikSub = normalizedSub;
+        await user.save();
+
+        return {
+            userId: user._id.toString(),
+            email: user.email,
+            username: user.username,
+            role: user.role,
+            identityProvider: user.identityProvider,
+            authentikSub: user.authentikSub,
+        };
+    } catch (error) {
+        logError("linkUserToAuthentikIdentity", error, { userId, email, username, authentikSub, force });
+        throw new Error(sanitizeErrorMessage(error, "Failed to link user to Authentik identity"));
+    }
+}

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docman-docs-site",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docman-docs-site",
-      "version": "2.2.3",
+      "version": "2.2.4",
       "dependencies": {
         "@docusaurus/core": "3.9.1",
         "@docusaurus/preset-classic": "3.9.1",

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docman-docs-site",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "private": true,
   "description": "Docusaurus documentation site for DocMan.",
   "scripts": {

--- a/docs/DEVELOPER_ONBOARDING.md
+++ b/docs/DEVELOPER_ONBOARDING.md
@@ -237,7 +237,7 @@ Every file should have a descriptive header:
  * @service documentService
  * @description Business logic for document management operations
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 ```

--- a/docs/architecture/ADR-005-suite-identity-migration.md
+++ b/docs/architecture/ADR-005-suite-identity-migration.md
@@ -1,0 +1,324 @@
+# ADR-005: Suite Identity Migration with Authentik
+
+**Status:** Proposed  
+**Date:** 2026-04-26
+
+## Context
+
+RDocMan was originally built as a standalone application and currently owns its own authentication, session, and role model. That worked when the application was isolated, but it becomes a problem as RDocMan is folded into the broader `RDSysCMD` suite alongside future applications.
+
+The suite direction now requires:
+
+- one shared login system across apps
+- one shared session and token authority
+- app-specific authorization to remain local where domain logic requires it
+
+At the suite level, Authentik has been selected as the shared identity provider. RDocMan therefore needs a migration path from app-local identity ownership to shared suite identity without breaking document, team, project, and review permissions.
+
+## Current Authentication Model
+
+### Identity and Credentials
+
+RDocMan currently stores user identity and credentials in its own `User` model:
+
+- `backend/src/models/User.js`
+
+The `User` model currently owns:
+
+- name and profile fields
+- email
+- username
+- hashed password
+- top-level application role
+- password reset token and expiry
+- hashed refresh token
+
+This means the current `users` collection is both:
+
+- the identity store
+- the app membership/profile store
+
+Those responsibilities will eventually need to be separated.
+
+### Login Flow
+
+Current login routes live in:
+
+- `backend/src/routes/authRoutes.js`
+- `backend/src/controllers/authController.js`
+
+Current flow:
+
+1. User submits email or username plus password to `/api/auth/login`.
+2. Backend looks up the local `User` record.
+3. Backend checks the password with bcrypt.
+4. Backend issues a JWT access token with `id` and `role`.
+5. Backend generates an opaque refresh token, hashes it, and stores the hash on the `User` record.
+6. Backend sets the refresh token in an `httpOnly` cookie.
+7. Frontend stores the access token and user payload in local storage.
+
+### Access Token Model
+
+Access token behavior currently lives in:
+
+- `backend/src/lib/secretToken.js`
+- `backend/src/lib/jwtSecret.js`
+
+Current characteristics:
+
+- signed with a local shared secret
+- contains `id` and `role`
+- valid for 5 days
+- verified directly by the backend
+
+The current access token is therefore both:
+
+- the app authentication artifact
+- the carrier of top-level authorization context
+
+### Refresh Token Model
+
+Refresh tokens are currently:
+
+- opaque random strings
+- stored only as a bcrypt hash on the `User` document
+- sent to the browser in an `httpOnly` cookie
+- rotated on login and refresh
+
+Refresh flow lives in:
+
+- `backend/src/controllers/authController.js`
+
+The current lookup strategy scans users with `refreshTokenHash` and compares hashes until a match is found. That is acceptable for a small standalone app but is not the right long-term shape for suite-wide identity.
+
+### Logout and Revocation
+
+Logout currently does two things:
+
+1. clears the stored refresh token hash on the matching user
+2. blacklists the current access token if one is supplied
+
+Blacklist behavior lives in:
+
+- `backend/src/models/BlacklistedToken.js`
+- `backend/src/lib/secretToken.js`
+
+The `blacklistedtokens` collection is therefore an app-local access-token revocation mechanism, not a suite-wide session authority.
+
+### Route Protection
+
+Authentication and authorization are split into two layers today:
+
+- authentication:
+  - `backend/src/lib/secretToken.js`
+  - `verifyAccessToken`
+- authorization:
+  - `backend/src/middleware/requireRole.js`
+
+This split is actually a good migration seam.
+
+Current route pattern is generally:
+
+```text
+verifyAccessToken -> requireRole(...) -> controller
+```
+
+The access token middleware:
+
+- reads the Bearer token
+- checks the blacklist
+- verifies the JWT
+- loads the current user from MongoDB
+- attaches the current user to `req.user`
+
+The role middleware then enforces the top-level app role hierarchy:
+
+- `viewer`
+- `editor`
+- `admin`
+- `superadmin`
+
+### Frontend Session Behavior
+
+The current Vue/Vuetify frontend auth behavior lives in:
+
+- `frontend-vue/src/composables/useAuth.js`
+- `frontend-vue/src/services/api.js`
+- `frontend-vue/src/router/index.js`
+
+The current frontend:
+
+- logs in through `/api/auth/login`
+- stores the access token in local storage
+- stores the current user payload in local storage
+- attaches the Bearer token on API requests
+- clears local state on `401`
+
+The refresh cookie exists on the backend, but the frontend does not yet act like a full centralized-session client. It behaves more like a classic app-local JWT frontend with a server-assisted refresh path.
+
+The legacy React frontend follows the same overall pattern: local storage holds the access token and frontend role checks often decode the token directly.
+
+## Current Authorization Model
+
+RDocMan authorization is not only top-level role-based. It also depends on domain objects and app-local relationships.
+
+Examples:
+
+- document access depends on ownership, stakeholder state, and review relationships
+- team access depends on ownership and membership
+- project access depends on ownership, collaboration, and team/project linkage
+- user profile access depends on whether the requesting user is acting on themselves
+
+This means the suite migration must preserve a crucial distinction:
+
+- authentication can move to Authentik
+- domain authorization must remain in RDocMan
+
+## Migration Seams
+
+### Strong Existing Seams
+
+The current codebase already has some useful boundaries:
+
+1. Authentication and role-checking are separate middleware layers.
+2. Controllers generally consume `req.user` instead of re-verifying tokens directly.
+3. Domain authorization often happens after request identity is resolved.
+4. The frontend already has a centralized auth composable and API client in the Vue app.
+
+These seams mean RDocMan does not need a destructive rewrite to adopt shared identity.
+
+### Tight Coupling That Must Be Reduced
+
+The following concerns are still tightly coupled and should be separated:
+
+1. `User` is both credential owner and app profile/member record.
+2. Access tokens encode the app role directly from the local user record.
+3. Refresh token ownership is attached directly to the `User` document.
+4. Logout assumes RDocMan is the source of truth for session revocation.
+5. Some frontend logic assumes the access token itself is the primary source of role truth.
+
+## Decision
+
+RDocMan should migrate to a model where:
+
+- Authentik owns authentication
+- Authentik owns session and refresh-token authority
+- RDocMan trusts Authentik-issued identity
+- RDocMan keeps app-specific authorization and membership logic
+
+RDocMan should not remain the long-term owner of:
+
+- primary credentials
+- suite session lifecycle
+- refresh-token lifecycle
+- suite-level user identity
+
+## Consequences
+
+### Positive
+
+- One suite login across RDSysCMD, RDocMan, and future apps.
+- Cleaner desktop SSO model.
+- Better separation between identity and domain authorization.
+- Future apps can adopt the same identity model from the start.
+
+### Tradeoffs
+
+- RDocMan backend will need an identity abstraction layer.
+- Existing user records need a migration/linking strategy.
+- Frontend login behavior will need to move away from app-local assumptions.
+- Some tests will need to be updated to reflect external identity flows.
+
+## Initial Migration Plan
+
+### Phase 1
+
+Document and stabilize the current boundaries.
+
+Immediate objective:
+
+- stop widening the local-auth surface area
+
+### Phase 2
+
+Add external identity mapping to the user model.
+
+Recommended fields:
+
+- `authentikSub`
+- optional identity metadata such as provider/source fields if needed later
+
+At that point, the `users` collection can begin shifting from:
+
+- credential store
+
+to:
+
+- RDocMan membership and profile-extension store
+
+### Phase 3
+
+Introduce an identity context layer in the backend.
+
+Instead of route protection being conceptually:
+
+```text
+verify local JWT -> load local user -> authorize
+```
+
+target:
+
+```text
+verify Authentik identity -> resolve local app user -> authorize
+```
+
+### Phase 4
+
+Teach the backend to trust Authentik-issued tokens.
+
+Likely replacement target for current `verifyAccessToken` behavior:
+
+- validate Authentik issuer
+- validate audience
+- validate signature
+- read `sub`
+- resolve linked local user
+- populate `req.user`
+
+Transitional implementation note:
+
+- existing local users should be linked explicitly to Authentik identities through `authentikSub`
+- automatic email-based identity linking should not be relied on silently at request time
+- the first migration mechanism should be an explicit mapping workflow that can be dry-run and audited
+
+### Phase 5
+
+Reduce dependence on local refresh and blacklist behavior.
+
+Long term:
+
+- `refreshTokenHash` should no longer be the primary refresh authority
+- `blacklistedtokens` should no longer be the primary session revocation mechanism
+
+Those concerns should move to the identity provider layer.
+
+## Immediate Next Backend Changes
+
+1. Add a lightweight identity-resolution abstraction around the current `verifyAccessToken` middleware.
+2. Add an external-identity field plan to `User`.
+3. Audit all places that assume the JWT payload is the source of role truth.
+4. Plan a transitional resolver that can support:
+   - existing local login
+   - future Authentik token validation
+5. Keep app-specific authorization in services and controllers, not in the identity provider.
+6. Add an explicit Authentik user-linking mechanism for existing users before enabling Authentik-only access paths.
+
+## References
+
+- `backend/src/models/User.js`
+- `backend/src/models/BlacklistedToken.js`
+- `backend/src/controllers/authController.js`
+- `backend/src/lib/secretToken.js`
+- `backend/src/middleware/requireRole.js`
+- `frontend-vue/src/composables/useAuth.js`
+- `frontend-vue/src/services/api.js`

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -58,6 +58,17 @@ Standardized UI components with built-in accessibility and consistent design:
 - 95% accessibility compliance
 - Consistent user experience across all interfaces
 
+### Platform and Identity
+
+#### [ADR-005: Suite Identity Migration with Authentik](./ADR-005-suite-identity-migration.md)
+**Status:** Proposed  
+**Date:** 2026-04-26
+
+Documents the current RDocMan authentication model and the migration seams needed to move from app-local identity ownership to shared suite identity through Authentik:
+- separates authentication from app-specific authorization
+- identifies `users` and `blacklistedtokens` as migration boundaries
+- defines a phased path toward shared RDSysCMD suite login
+
 ## Decision Timeline
 
 ```mermaid
@@ -71,6 +82,9 @@ timeline
     2024-01-15 : Frontend Refactoring Phase
                : ADR-003 Custom Hooks Pattern
                : ADR-004 Shared Component Library
+
+    2026-04-26 : Suite Identity Planning
+               : ADR-005 Authentik Identity Migration
 ```
 
 ## Impact Summary
@@ -122,12 +136,12 @@ Based on the implemented ADRs, the DocMan architecture follows these key princip
 ## Future Considerations
 
 ### Potential Future ADRs
-- **ADR-005**: API Versioning Strategy
-- **ADR-006**: Error Handling Standardization
-- **ADR-007**: Security Implementation Patterns
-- **ADR-008**: Deployment and CI/CD Strategy
-- **ADR-009**: Monitoring and Observability
-- **ADR-010**: Scalability Architecture
+- **ADR-006**: API Versioning Strategy
+- **ADR-007**: Error Handling Standardization
+- **ADR-008**: Security Implementation Patterns
+- **ADR-009**: Deployment and CI/CD Strategy
+- **ADR-010**: Monitoring and Observability
+- **ADR-011**: Scalability Architecture
 
 ### Technology Evolution
 As the project evolves, these ADRs may need to be:

--- a/frontend-vue/package-lock.json
+++ b/frontend-vue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rd-docman-frontend-vue",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rd-docman-frontend-vue",
-      "version": "2.2.3",
+      "version": "2.2.4",
       "dependencies": {
         "@mdi/font": "^7.4.47",
         "axios": "^1.11.0",

--- a/frontend-vue/package.json
+++ b/frontend-vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rd-docman-frontend-vue",
   "private": true,
-  "version": "2.2.3",
+  "version": "2.2.4",
   "type": "module",
   "description": "Vue and Vuetify migration foundation for DocMan.",
   "scripts": {

--- a/frontend-vue/src/App.vue
+++ b/frontend-vue/src/App.vue
@@ -99,6 +99,13 @@ const navItems = [
     to: '/projects',
     roles: ['editor', 'admin', 'superadmin'],
   },
+  {
+    title: 'Authentik Linking',
+    subtitle: 'Suite identity mapping',
+    icon: 'mdi-account-key-outline',
+    to: '/admin/authentik-linking',
+    roles: ['superadmin'],
+  },
 ];
 
 const visibleNavItems = computed(() => {

--- a/frontend-vue/src/composables/useAuth.js
+++ b/frontend-vue/src/composables/useAuth.js
@@ -1,6 +1,12 @@
 import { computed, reactive } from 'vue';
 import { api } from '@/services/api';
 import { getStorageKey } from '@/runtime/config';
+import {
+  beginAuthentikLogin,
+  consumePostLoginRedirect,
+  exchangeAuthentikCode,
+  isAuthentikEnabled,
+} from '@/services/authentikAuth';
 
 const state = reactive({
   token: null,
@@ -44,11 +50,26 @@ function syncStateFromStorage() {
   state.user = readStoredUser();
 }
 
+async function hydrateCurrentSession() {
+  const response = await api.get('/auth/me');
+  const user = response.data?.user;
+  if (!user) {
+    throw new Error('Unable to resolve the current DocMan session.');
+  }
+
+  persistSession(state.token, user);
+  return {
+    user,
+    identity: response.data?.identity || null,
+  };
+}
+
 export function useAuth() {
   syncStateFromStorage();
 
   const isAuthenticated = computed(() => Boolean(state.token));
   const userRole = computed(() => state.user?.role || null);
+  const authentikAvailable = computed(() => isAuthentikEnabled());
 
   async function login(email, password) {
     state.loading = true;
@@ -81,12 +102,49 @@ export function useAuth() {
     return allowed.includes(userRole.value);
   }
 
+  async function startAuthentikLogin(redirectPath = '/documents') {
+    state.error = '';
+    await beginAuthentikLogin(redirectPath);
+  }
+
+  async function completeAuthentikLogin(code, returnedState) {
+    state.loading = true;
+    state.error = '';
+
+    try {
+      const tokenSet = await exchangeAuthentikCode(code, returnedState);
+      if (!tokenSet.access_token) {
+        throw new Error('Authentik did not return an access token.');
+      }
+
+      state.token = tokenSet.access_token;
+      localStorage.setItem(getStorageKey('token'), tokenSet.access_token);
+
+      const session = await hydrateCurrentSession();
+
+      return {
+        user: session.user,
+        identity: session.identity,
+        redirectPath: consumePostLoginRedirect(),
+      };
+    } catch (error) {
+      clearSession();
+      state.error = error.message || 'Authentik login failed.';
+      throw error;
+    } finally {
+      state.loading = false;
+    }
+  }
+
   return {
     state,
     isAuthenticated,
     userRole,
+    authentikAvailable,
     login,
     logout,
     hasRole,
+    startAuthentikLogin,
+    completeAuthentikLogin,
   };
 }

--- a/frontend-vue/src/lib/pkce.js
+++ b/frontend-vue/src/lib/pkce.js
@@ -1,0 +1,19 @@
+function base64UrlEncode(buffer) {
+  return btoa(String.fromCharCode(...new Uint8Array(buffer)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
+}
+
+export function generateRandomString(length = 64) {
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~';
+  const values = crypto.getRandomValues(new Uint8Array(length));
+  return Array.from(values, (value) => alphabet[value % alphabet.length]).join('');
+}
+
+export async function createPkceChallenge(verifier) {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(verifier);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return base64UrlEncode(digest);
+}

--- a/frontend-vue/src/router/index.js
+++ b/frontend-vue/src/router/index.js
@@ -1,6 +1,7 @@
 import { createMemoryHistory, createRouter, createWebHistory } from 'vue-router';
 import SuiteHome from '@/views/SuiteHome.vue';
 import LoginView from '@/views/auth/LoginView.vue';
+import AuthentikCallbackView from '@/views/auth/AuthentikCallbackView.vue';
 import DocumentsView from '@/views/documents/DocumentsView.vue';
 import DocumentDetailView from '@/views/documents/DocumentDetailView.vue';
 import DocumentCreateView from '@/views/documents/DocumentCreateView.vue';
@@ -9,6 +10,7 @@ import BooksView from '@/views/books/BooksView.vue';
 import CategoriesView from '@/views/categories/CategoriesView.vue';
 import TeamsView from '@/views/teams/TeamsView.vue';
 import ProjectsView from '@/views/projects/ProjectsView.vue';
+import AuthentikLinkingView from '@/views/admin/AuthentikLinkingView.vue';
 import { useAuth } from '@/composables/useAuth';
 
 const routes = [
@@ -21,6 +23,12 @@ const routes = [
     path: '/login',
     name: 'login',
     component: LoginView,
+    meta: { public: true },
+  },
+  {
+    path: '/auth/callback',
+    name: 'authentik-callback',
+    component: AuthentikCallbackView,
     meta: { public: true },
   },
   {
@@ -70,6 +78,12 @@ const routes = [
     name: 'projects',
     component: ProjectsView,
     meta: { requiresAuth: true, roles: ['editor', 'admin', 'superadmin'] },
+  },
+  {
+    path: '/admin/authentik-linking',
+    name: 'authentik-linking',
+    component: AuthentikLinkingView,
+    meta: { requiresAuth: true, roles: ['superadmin'] },
   },
 ];
 

--- a/frontend-vue/src/runtime/config.js
+++ b/frontend-vue/src/runtime/config.js
@@ -5,6 +5,12 @@ const defaults = {
   routerBase: import.meta.env.BASE_URL || '/',
   hostApp: 'RDocMan',
   storageNamespace: 'docman',
+  authentikEnabled: import.meta.env.VITE_AUTHENTIK_ENABLED === 'true',
+  authentikClientId: import.meta.env.VITE_AUTHENTIK_CLIENT_ID || '',
+  authentikAuthorizationUrl: import.meta.env.VITE_AUTHENTIK_AUTHORIZATION_URL || '',
+  authentikTokenUrl: import.meta.env.VITE_AUTHENTIK_TOKEN_URL || '',
+  authentikRedirectUri: import.meta.env.VITE_AUTHENTIK_REDIRECT_URI || '',
+  authentikScope: import.meta.env.VITE_AUTHENTIK_SCOPE || 'openid profile email',
 };
 
 function readWindowConfig() {

--- a/frontend-vue/src/services/authentikAdmin.js
+++ b/frontend-vue/src/services/authentikAdmin.js
@@ -1,0 +1,14 @@
+import { api } from '@/services/api';
+
+export async function fetchUnlinkedAuthentikUsers(limit = 250) {
+  const response = await api.get('/users/authentik/unlinked', {
+    params: { limit },
+  });
+
+  return response.data;
+}
+
+export async function linkAuthentikUser(payload) {
+  const response = await api.post('/users/authentik/link', payload);
+  return response.data;
+}

--- a/frontend-vue/src/services/authentikAuth.js
+++ b/frontend-vue/src/services/authentikAuth.js
@@ -1,0 +1,103 @@
+import { getRuntimeConfig, getStorageKey } from '@/runtime/config';
+import { createPkceChallenge, generateRandomString } from '@/lib/pkce';
+
+function getAuthentikConfig() {
+  const runtimeConfig = getRuntimeConfig();
+
+  return {
+    enabled: Boolean(runtimeConfig.authentikEnabled),
+    clientId: runtimeConfig.authentikClientId,
+    authorizationUrl: runtimeConfig.authentikAuthorizationUrl,
+    tokenUrl: runtimeConfig.authentikTokenUrl,
+    redirectUri: runtimeConfig.authentikRedirectUri,
+    scope: runtimeConfig.authentikScope || 'openid profile email',
+  };
+}
+
+function assertAuthentikConfigured(config) {
+  if (!config.enabled) {
+    throw new Error('Authentik sign-in is not enabled.');
+  }
+
+  if (!config.clientId || !config.authorizationUrl || !config.tokenUrl || !config.redirectUri) {
+    throw new Error('Authentik configuration is incomplete.');
+  }
+}
+
+export function isAuthentikEnabled() {
+  return getAuthentikConfig().enabled;
+}
+
+export async function beginAuthentikLogin(redirectPath = '/documents') {
+  const config = getAuthentikConfig();
+  assertAuthentikConfigured(config);
+
+  const verifier = generateRandomString(96);
+  const challenge = await createPkceChallenge(verifier);
+  const state = generateRandomString(48);
+
+  localStorage.setItem(getStorageKey('authentik:pkce_verifier'), verifier);
+  localStorage.setItem(getStorageKey('authentik:oauth_state'), state);
+  localStorage.setItem(getStorageKey('authentik:post_login_redirect'), redirectPath);
+
+  const params = new URLSearchParams({
+    client_id: config.clientId,
+    response_type: 'code',
+    redirect_uri: config.redirectUri,
+    scope: config.scope,
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
+    state,
+  });
+
+  window.location.assign(`${config.authorizationUrl}?${params.toString()}`);
+}
+
+export async function exchangeAuthentikCode(code, returnedState) {
+  const config = getAuthentikConfig();
+  assertAuthentikConfigured(config);
+
+  const storedState = localStorage.getItem(getStorageKey('authentik:oauth_state'));
+  const verifier = localStorage.getItem(getStorageKey('authentik:pkce_verifier'));
+
+  if (!storedState || storedState !== returnedState) {
+    throw new Error('Invalid Authentik OAuth state.');
+  }
+
+  if (!verifier) {
+    throw new Error('Missing PKCE verifier for Authentik login.');
+  }
+
+  const formData = new URLSearchParams({
+    grant_type: 'authorization_code',
+    client_id: config.clientId,
+    code,
+    redirect_uri: config.redirectUri,
+    code_verifier: verifier,
+  });
+
+  const response = await fetch(config.tokenUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: formData.toString(),
+  });
+
+  const payload = await response.json();
+  if (!response.ok) {
+    throw new Error(payload.error_description || payload.error || 'Failed to exchange Authentik authorization code.');
+  }
+
+  localStorage.removeItem(getStorageKey('authentik:oauth_state'));
+  localStorage.removeItem(getStorageKey('authentik:pkce_verifier'));
+
+  return payload;
+}
+
+export function consumePostLoginRedirect() {
+  const key = getStorageKey('authentik:post_login_redirect');
+  const redirect = localStorage.getItem(key) || '/documents';
+  localStorage.removeItem(key);
+  return redirect;
+}

--- a/frontend-vue/src/styles/main.css
+++ b/frontend-vue/src/styles/main.css
@@ -26,3 +26,6 @@ body {
   letter-spacing: 0;
 }
 
+.authentik-linking__actions {
+  white-space: nowrap;
+}

--- a/frontend-vue/src/views/admin/AuthentikLinkingView.vue
+++ b/frontend-vue/src/views/admin/AuthentikLinkingView.vue
@@ -1,0 +1,176 @@
+<template>
+  <v-container class="py-8" fluid>
+    <div class="d-flex flex-wrap align-center justify-space-between ga-4 mb-6">
+      <div>
+        <div class="text-overline text-primary">Suite Identity</div>
+        <h1 class="text-h4 font-weight-bold">Authentik Linking</h1>
+        <p class="text-body-1 text-medium-emphasis mb-0">
+          Link existing RDocMan users to Authentik subject IDs so suite-issued tokens can resolve local authorization.
+        </p>
+      </div>
+      <div class="d-flex align-center ga-3">
+        <v-chip color="primary" variant="tonal" size="large">
+          {{ users.length }} unlinked
+        </v-chip>
+        <v-btn
+          color="primary"
+          prepend-icon="mdi-refresh"
+          :loading="loading"
+          @click="loadUsers"
+        >
+          Refresh
+        </v-btn>
+      </div>
+    </div>
+
+    <v-alert
+      class="mb-4"
+      type="info"
+      variant="tonal"
+      density="comfortable"
+    >
+      This tool performs explicit user-to-subject linking. It does not auto-link accounts silently by email during authentication.
+    </v-alert>
+
+    <v-alert
+      v-if="error"
+      class="mb-4"
+      type="error"
+      variant="tonal"
+      density="comfortable"
+    >
+      {{ error }}
+    </v-alert>
+
+    <v-alert
+      v-if="successMessage"
+      class="mb-4"
+      type="success"
+      variant="tonal"
+      density="comfortable"
+    >
+      {{ successMessage }}
+    </v-alert>
+
+    <v-card>
+      <v-card-text>
+        <v-skeleton-loader v-if="loading" type="table" />
+
+        <v-empty-state
+          v-else-if="users.length === 0"
+          icon="mdi-account-check-outline"
+          title="No unlinked users found"
+          text="Every visible RDocMan user already has an Authentik subject mapping."
+        />
+
+        <v-table v-else>
+          <thead>
+            <tr>
+              <th>User</th>
+              <th>Role</th>
+              <th>Lookup</th>
+              <th>Authentik Subject</th>
+              <th>Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="user in users" :key="user._id">
+              <td>
+                <div class="font-weight-medium">
+                  {{ [user.firstname, user.lastname].filter(Boolean).join(' ') || user.username }}
+                </div>
+                <div class="text-body-2 text-medium-emphasis">
+                  {{ user.email }}
+                </div>
+              </td>
+              <td>
+                <v-chip size="small" variant="tonal" color="primary">
+                  {{ user.role }}
+                </v-chip>
+              </td>
+              <td class="text-body-2 text-medium-emphasis">
+                <div><strong>ID:</strong> {{ user._id }}</div>
+                <div><strong>Username:</strong> {{ user.username }}</div>
+              </td>
+              <td>
+                <v-text-field
+                  v-model="linkInputs[user._id]"
+                  label="authentikSub"
+                  density="compact"
+                  hide-details
+                  placeholder="Paste Authentik subject ID"
+                />
+              </td>
+              <td class="authentik-linking__actions">
+                <v-btn
+                  color="primary"
+                  variant="flat"
+                  size="small"
+                  :loading="linkingUserId === user._id"
+                  :disabled="!linkInputs[user._id]?.trim()"
+                  @click="linkUser(user)"
+                >
+                  Link
+                </v-btn>
+              </td>
+            </tr>
+          </tbody>
+        </v-table>
+      </v-card-text>
+    </v-card>
+  </v-container>
+</template>
+
+<script setup>
+import { onMounted, ref } from 'vue';
+import { fetchUnlinkedAuthentikUsers, linkAuthentikUser } from '@/services/authentikAdmin';
+
+const users = ref([]);
+const loading = ref(false);
+const linkingUserId = ref('');
+const error = ref('');
+const successMessage = ref('');
+const linkInputs = ref({});
+
+async function loadUsers() {
+  loading.value = true;
+  error.value = '';
+
+  try {
+    const response = await fetchUnlinkedAuthentikUsers();
+    users.value = response.users || [];
+  } catch (loadError) {
+    error.value = loadError.response?.data?.message || 'Failed to load unlinked users.';
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function linkUser(user) {
+  const authentikSub = linkInputs.value[user._id]?.trim();
+  if (!authentikSub) {
+    return;
+  }
+
+  linkingUserId.value = user._id;
+  error.value = '';
+  successMessage.value = '';
+
+  try {
+    const response = await linkAuthentikUser({
+      userId: user._id,
+      authentikSub,
+    });
+
+    users.value = users.value.filter((entry) => entry._id !== user._id);
+    delete linkInputs.value[user._id];
+    successMessage.value = response.message || `Linked ${user.email} successfully.`;
+  } catch (linkError) {
+    error.value = linkError.response?.data?.message || 'Failed to link user to Authentik.';
+  } finally {
+    linkingUserId.value = '';
+  }
+}
+
+onMounted(loadUsers);
+</script>

--- a/frontend-vue/src/views/auth/AuthentikCallbackView.vue
+++ b/frontend-vue/src/views/auth/AuthentikCallbackView.vue
@@ -1,0 +1,71 @@
+<template>
+  <v-container class="py-10" fluid>
+    <v-row justify="center">
+      <v-col cols="12" md="7" lg="5">
+        <v-card class="pa-2">
+          <v-card-title class="text-h5 font-weight-bold">
+            Completing suite sign-in
+          </v-card-title>
+          <v-card-subtitle>
+            We are validating your Resonance Designs account and resolving your local RDocMan access.
+          </v-card-subtitle>
+
+          <v-card-text>
+            <v-alert
+              v-if="error"
+              type="error"
+              variant="tonal"
+              density="comfortable"
+              class="mb-4"
+            >
+              {{ error }}
+            </v-alert>
+
+            <div v-else class="d-flex align-center ga-4">
+              <v-progress-circular indeterminate color="primary" />
+              <span class="text-body-1">Please wait while we complete sign-in.</span>
+            </div>
+
+            <v-btn
+              v-if="error"
+              class="mt-4"
+              color="primary"
+              variant="flat"
+              to="/login"
+            >
+              Back to login
+            </v-btn>
+          </v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script setup>
+import { onMounted, ref } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { useAuth } from '@/composables/useAuth';
+
+const route = useRoute();
+const router = useRouter();
+const error = ref('');
+const { completeAuthentikLogin } = useAuth();
+
+onMounted(async () => {
+  const code = typeof route.query.code === 'string' ? route.query.code : '';
+  const returnedState = typeof route.query.state === 'string' ? route.query.state : '';
+
+  if (!code || !returnedState) {
+    error.value = 'Missing Authentik authorization response parameters.';
+    return;
+  }
+
+  try {
+    const result = await completeAuthentikLogin(code, returnedState);
+    await router.replace(result.redirectPath || '/documents');
+  } catch (callbackError) {
+    error.value = callbackError.message || 'Failed to complete Authentik sign-in.';
+  }
+});
+</script>

--- a/frontend-vue/src/views/auth/LoginView.vue
+++ b/frontend-vue/src/views/auth/LoginView.vue
@@ -4,10 +4,10 @@
       <v-col cols="12" md="7" lg="5">
         <v-card class="pa-2">
           <v-card-title class="text-h4 font-weight-bold">
-            Sign in to DocMan
+            Sign in to RDocMan
           </v-card-title>
           <v-card-subtitle>
-            Use your existing DocMan account to open the documents module.
+            Use your Resonance Designs account when available, or keep using the local DocMan login during migration.
           </v-card-subtitle>
 
           <v-card-text>
@@ -44,9 +44,27 @@
                 block
                 :loading="state.loading"
               >
-                Sign in
+                Sign in with local DocMan account
               </v-btn>
             </v-form>
+
+            <div v-if="authentikAvailable" class="my-6 d-flex align-center ga-3">
+              <v-divider />
+              <span class="text-caption text-medium-emphasis">or</span>
+              <v-divider />
+            </div>
+
+            <v-btn
+              v-if="authentikAvailable"
+              color="secondary"
+              variant="tonal"
+              block
+              prepend-icon="mdi-account-key-outline"
+              :loading="state.loading"
+              @click="submitAuthentik"
+            >
+              Sign in with Resonance Account
+            </v-btn>
           </v-card-text>
         </v-card>
       </v-col>
@@ -61,7 +79,7 @@ import { useAuth } from '@/composables/useAuth';
 
 const route = useRoute();
 const router = useRouter();
-const { login, state } = useAuth();
+const { login, state, authentikAvailable, startAuthentikLogin } = useAuth();
 
 const email = ref('');
 const password = ref('');
@@ -70,5 +88,8 @@ async function submit() {
   await login(email.value, password.value);
   await router.push(route.query.redirect || '/documents');
 }
-</script>
 
+async function submitAuthentik() {
+  await startAuthentikLogin(typeof route.query.redirect === 'string' ? route.query.redirect : '/documents');
+}
+</script>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rd-docman-frontend",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rd-docman-frontend",
-      "version": "2.2.3",
+      "version": "2.2.4",
       "license": "UNLICENSED",
       "dependencies": {
         "@hookform/resolvers": "^3.3.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rd-docman-frontend",
   "private": true,
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "DocMan is a document management application for all sorts of documents. Track updates, schedule reviews, categorize, and upload versions of your docs. DocMan hopes to be the most comprehensive piece of software to manage all of your documentation. You can schedule your documentation for review between stakeholders, the original authors, contributors, relevant tech leads, etc... Categorize, analyze, version repositories, and basically everything you would need to keep your documentation well organized, maintained, analyzed, and backed up.",
   "keywords": [
     "Document Management",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/App.jsx
  * @description Main application component that handles routing and authentication state
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { Route, Routes } from "react-router";

--- a/frontend/src/README.md
+++ b/frontend/src/README.md
@@ -11,7 +11,7 @@ All frontend files should include a comment header with the following format:
  * @page [ComponentName]
  * @description [Brief description of the component/page]
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 ```

--- a/frontend/src/__tests__/hooks/useFormData.test.js
+++ b/frontend/src/__tests__/hooks/useFormData.test.js
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/__tests__/hooks/useFormData.test.js
  * @description Unit tests for useFormData custom hook
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { renderHook, waitFor } from '@testing-library/react';

--- a/frontend/src/__tests__/setup.js
+++ b/frontend/src/__tests__/setup.js
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/__tests__/setup.js
  * @description Global test setup and configuration for React components
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { expect, afterEach, vi } from 'vitest';

--- a/frontend/src/components/AccountNav.jsx
+++ b/frontend/src/components/AccountNav.jsx
@@ -4,7 +4,7 @@
  * @component AccountNav
  * @description Account navigation dropdown component with profile, teams, and projects links
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/BookTable.jsx
+++ b/frontend/src/components/BookTable.jsx
@@ -4,7 +4,7 @@
  * @component BookTable
  * @description Component for displaying a book in a table row with actions.
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/CatTable.jsx
+++ b/frontend/src/components/CatTable.jsx
@@ -4,7 +4,7 @@
  * @component CatTable
  * @description Category table component for displaying and managing document categories
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/DocCard.jsx
+++ b/frontend/src/components/DocCard.jsx
@@ -4,7 +4,7 @@
  * @component DocCard
  * @description Component for displaying a document card with title, author, description, and review date.
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/DocTable.jsx
+++ b/frontend/src/components/DocTable.jsx
@@ -4,7 +4,7 @@
  * @component DocTable
  * @description Component for displaying a document in a table row with actions.
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/DocsNotFound.jsx
+++ b/frontend/src/components/DocsNotFound.jsx
@@ -4,7 +4,7 @@
  * @component DocNotFound
  * @description Empty state component displayed when no documents are found with call-to-action
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { NotebookIcon } from "lucide-react";

--- a/frontend/src/components/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary.jsx
@@ -4,7 +4,7 @@
  * @component ErrorBoundary
  * @description Component for catching and displaying React errors
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import React from "react";

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -4,7 +4,7 @@
  * @component Footer
  * @description Application footer component with copyright information and company branding
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 /**

--- a/frontend/src/components/InlineLoader.jsx
+++ b/frontend/src/components/InlineLoader.jsx
@@ -4,7 +4,7 @@
  * @component InlineLoader
  * @description Component for loading indicators in the UI.
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import React from 'react';

--- a/frontend/src/components/LoadingSpinner.jsx
+++ b/frontend/src/components/LoadingSpinner.jsx
@@ -4,7 +4,7 @@
  * @component LoadingSpinner
  * @description Component for displaying a loading spinner with an optional message. The component can be customized in terms of size, color and whether it should cover the entire screen or not.
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import React from 'react';

--- a/frontend/src/components/NavAdmin.jsx
+++ b/frontend/src/components/NavAdmin.jsx
@@ -4,7 +4,7 @@
  * @component NavAdmin
  * @description Component for displaying navigation links for the admin panel.
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { Link } from "react-router";

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -4,7 +4,7 @@
  * @component Navbar
  * @description Component for the main navigation bar with responsive menu and authentication handling.
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/NotificationBell.jsx
+++ b/frontend/src/components/NotificationBell.jsx
@@ -4,7 +4,7 @@
  * @component NotificationBell
  * @description Notification bell component with dropdown for displaying user notifications
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/PaginatedBookTable.jsx
+++ b/frontend/src/components/PaginatedBookTable.jsx
@@ -4,7 +4,7 @@
  * @component PaginatedBookTable
  * @description Paginated table component for displaying books with sorting, filtering, and bulk actions
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/PaginatedCatTable.jsx
+++ b/frontend/src/components/PaginatedCatTable.jsx
@@ -4,7 +4,7 @@
  * @component PaginatedCatTable
  * @description Component for displaying categories in a paginated table.
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/PaginatedDocTable.jsx
+++ b/frontend/src/components/PaginatedDocTable.jsx
@@ -4,7 +4,7 @@
  * @component PaginatedDocTable
  * @description Paginated table component for displaying documents with sorting, filtering, and bulk actions
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/PaginatedFileVersionTable.jsx
+++ b/frontend/src/components/PaginatedFileVersionTable.jsx
@@ -4,7 +4,7 @@
  * @component PaginatedFileVersionTable
  * @description Paginated and sortable table for document file version history (sortable by Version and Uploaded)
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/PaginatedUserTable.jsx
+++ b/frontend/src/components/PaginatedUserTable.jsx
@@ -4,7 +4,7 @@
  * @component PaginatedUserTable
  * @description Paginated table component for displaying users with administrative controls and filtering
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/ProtectedRoutes.jsx
+++ b/frontend/src/components/ProtectedRoutes.jsx
@@ -4,7 +4,7 @@
  * @component ProtectedRoutes
  * @description Route protection component for handling authentication and authorization
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { Navigate } from "react-router";

--- a/frontend/src/components/RateLimitedUI.jsx
+++ b/frontend/src/components/RateLimitedUI.jsx
@@ -4,7 +4,7 @@
  * @component RateLimitedUI
  * @description Rate limit notification component displayed when API request limits are exceeded
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { ZapIcon } from "lucide-react";

--- a/frontend/src/components/ReviewCompletionToggle.jsx
+++ b/frontend/src/components/ReviewCompletionToggle.jsx
@@ -4,7 +4,7 @@
  * @component ReviewCompletionToggle
  * @description Toggle component for review assignees to mark their review as complete
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState } from "react";

--- a/frontend/src/components/ReviewStatusSummary.jsx
+++ b/frontend/src/components/ReviewStatusSummary.jsx
@@ -4,7 +4,7 @@
  * @component ReviewStatusSummary
  * @description Summary component showing overall review completion status
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { CheckCircleIcon, ClockIcon, UsersIcon } from "lucide-react";

--- a/frontend/src/components/UserTable.jsx
+++ b/frontend/src/components/UserTable.jsx
@@ -4,7 +4,7 @@
  * @component UserTable
  * @description Component for displaying a user in a table row with actions.
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/filters/DateRangeFilter.jsx
+++ b/frontend/src/components/filters/DateRangeFilter.jsx
@@ -4,7 +4,7 @@
  * @component DateRangeFilter
  * @description Date range filter component with calendar picker for filtering by date periods
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { CalendarIcon, XIcon } from "lucide-react";

--- a/frontend/src/components/filters/DropdownFilter.jsx
+++ b/frontend/src/components/filters/DropdownFilter.jsx
@@ -4,7 +4,7 @@
  * @component DropdownFilter
  * @description Dropdown filter component with search functionality for selecting filter options
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { ChevronDownIcon, XIcon } from "lucide-react";

--- a/frontend/src/components/filters/FilterBar.jsx
+++ b/frontend/src/components/filters/FilterBar.jsx
@@ -4,7 +4,7 @@
  * @component FilterBar
  * @description Comprehensive filter bar with search, dropdown filters, date range, and clear all functionality
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { FilterIcon, XIcon } from "lucide-react";

--- a/frontend/src/components/filters/SearchInput.jsx
+++ b/frontend/src/components/filters/SearchInput.jsx
@@ -4,7 +4,7 @@
  * @component SearchInput
  * @description Reusable search input component with clear button and customizable placeholder for filtering data
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { SearchIcon, XIcon } from "lucide-react";

--- a/frontend/src/components/filters/SortableHeader.jsx
+++ b/frontend/src/components/filters/SortableHeader.jsx
@@ -4,7 +4,7 @@
  * @component SortableHeader
  * @description Sortable table header component with visual indicators for column sorting
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { ChevronUpIcon, ChevronDownIcon, ChevronsUpDownIcon } from "lucide-react";

--- a/frontend/src/components/forms/BookBasicFields.jsx
+++ b/frontend/src/components/forms/BookBasicFields.jsx
@@ -4,7 +4,7 @@
  * @component BookBasicFields
  * @description Reusable form component for basic book fields (title, description, category)
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/forms/DocumentBasicFields.jsx
+++ b/frontend/src/components/forms/DocumentBasicFields.jsx
@@ -4,7 +4,7 @@
  * @component DocumentBasicFields
  * @description Reusable form component for basic document fields (title, description, author, category, review date)
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { Controller } from "react-hook-form";

--- a/frontend/src/components/forms/DocumentSelection.jsx
+++ b/frontend/src/components/forms/DocumentSelection.jsx
@@ -4,7 +4,7 @@
  * @component DocumentSelection
  * @description Reusable component for selecting documents using TeamDetailPage pattern with table-based selection
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/components/forms/EnhancedDocumentFields.jsx
+++ b/frontend/src/components/forms/EnhancedDocumentFields.jsx
@@ -4,7 +4,7 @@
  * @component EnhancedDocumentFields
  * @description Enhanced form component for document fields with new review system
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { Controller } from "react-hook-form";

--- a/frontend/src/components/forms/ExternalContactsManager.jsx
+++ b/frontend/src/components/forms/ExternalContactsManager.jsx
@@ -4,7 +4,7 @@
  * @component ExternalContactsManager
  * @description Reusable component for managing external contacts with add, edit, and remove functionality
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { X, Plus, Edit2, Check, XCircle } from "lucide-react";

--- a/frontend/src/components/forms/ReviewAssignments.jsx
+++ b/frontend/src/components/forms/ReviewAssignments.jsx
@@ -4,7 +4,7 @@
  * @component ReviewAssignments
  * @description Reusable component for managing document review assignments with date scheduling and notes
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { Controller } from "react-hook-form";

--- a/frontend/src/components/forms/StakeholderSelection.jsx
+++ b/frontend/src/components/forms/StakeholderSelection.jsx
@@ -4,7 +4,7 @@
  * @component StakeholderSelection
  * @description Reusable component for selecting stakeholders and owners with chip-based UI
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { X } from "lucide-react";

--- a/frontend/src/components/modals/ConfirmationModal.jsx
+++ b/frontend/src/components/modals/ConfirmationModal.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/components/modals/ConfirmationModal.jsx
  * @component ConfirmationModal
  * @description A reusable confirmation modal component for confirming user actions
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import React from 'react';

--- a/frontend/src/components/projects/AddCollaboratorModal.jsx
+++ b/frontend/src/components/projects/AddCollaboratorModal.jsx
@@ -4,7 +4,7 @@
  * @component AddCollaboratorModal
  * @description Modal component for adding collaborators to a project
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/projects/CollaboratorCard.jsx
+++ b/frontend/src/components/projects/CollaboratorCard.jsx
@@ -4,7 +4,7 @@
  * @component CollaboratorCard
  * @description Card component for displaying project collaborators
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { MoreVerticalIcon, UserIcon, MailIcon, PhoneIcon } from 'lucide-react';

--- a/frontend/src/components/projects/ProjectBooksTable.jsx
+++ b/frontend/src/components/projects/ProjectBooksTable.jsx
@@ -4,7 +4,7 @@
  * @component ProjectBooksTable
  * @description Specialized table component for managing books in projects with checkbox selection and bulk actions
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/projects/ProjectCard.jsx
+++ b/frontend/src/components/projects/ProjectCard.jsx
@@ -4,7 +4,7 @@
  * @component ProjectCard
  * @description Project card component displaying project summary, status, priority, and quick actions
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/components/projects/ProjectDocumentsTable.jsx
+++ b/frontend/src/components/projects/ProjectDocumentsTable.jsx
@@ -4,7 +4,7 @@
  * @component ProjectDocumentsTable
  * @description Specialized table component for managing documents in projects with checkbox selection and bulk actions
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/shared/BaseModal.jsx
+++ b/frontend/src/components/shared/BaseModal.jsx
@@ -4,7 +4,7 @@
  * @component BaseModal
  * @description Reusable base modal component with consistent styling and behavior
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useEffect } from "react";

--- a/frontend/src/components/shared/BaseModal.stories.jsx
+++ b/frontend/src/components/shared/BaseModal.stories.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/components/shared/BaseModal.stories.jsx
  * @description Storybook stories for BaseModal component
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState } from 'react';

--- a/frontend/src/components/shared/DataTable.jsx
+++ b/frontend/src/components/shared/DataTable.jsx
@@ -4,7 +4,7 @@
  * @component DataTable
  * @description Reusable data table component with sorting, pagination, and action buttons
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState } from "react";

--- a/frontend/src/components/shared/DataTable.stories.jsx
+++ b/frontend/src/components/shared/DataTable.stories.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/components/shared/DataTable.stories.jsx
  * @description Storybook stories for DataTable component
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState } from 'react';

--- a/frontend/src/components/shared/ErrorBoundary.jsx
+++ b/frontend/src/components/shared/ErrorBoundary.jsx
@@ -4,7 +4,7 @@
  * @component ErrorBoundary
  * @description React error boundary component for graceful error handling and user feedback
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { Component } from "react";

--- a/frontend/src/components/shared/FormField.jsx
+++ b/frontend/src/components/shared/FormField.jsx
@@ -4,7 +4,7 @@
  * @component FormField
  * @description Reusable form field component with consistent styling, validation, and error handling
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import PropTypes from "prop-types";

--- a/frontend/src/components/shared/FormField.stories.jsx
+++ b/frontend/src/components/shared/FormField.stories.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/components/shared/FormField.stories.jsx
  * @description Storybook stories for FormField component
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState } from 'react';

--- a/frontend/src/components/shared/FormModal.jsx
+++ b/frontend/src/components/shared/FormModal.jsx
@@ -4,7 +4,7 @@
  * @component FormModal
  * @description Reusable form modal component with validation, loading states, and error handling
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import PropTypes from "prop-types";

--- a/frontend/src/components/shared/LoadingSpinner.jsx
+++ b/frontend/src/components/shared/LoadingSpinner.jsx
@@ -4,7 +4,7 @@
  * @component LoadingSpinner
  * @description Reusable loading spinner component with various sizes and styles
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import PropTypes from "prop-types";

--- a/frontend/src/components/shared/LoadingSpinner.stories.jsx
+++ b/frontend/src/components/shared/LoadingSpinner.stories.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/components/shared/LoadingSpinner.stories.jsx
  * @description Storybook stories for LoadingSpinner component
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import LoadingSpinner from './LoadingSpinner';

--- a/frontend/src/components/shared/index.js
+++ b/frontend/src/components/shared/index.js
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/components/shared/index.js
  * @description Centralized export for all shared/reusable components
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/system/ConfirmActionModal.jsx
+++ b/frontend/src/components/system/ConfirmActionModal.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/components/system/ConfirmActionModal.jsx
  * @component ConfirmActionModal
  * @description Confirmation modal for dangerous system actions
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import PropTypes from "prop-types";

--- a/frontend/src/components/system/DangerZone.jsx
+++ b/frontend/src/components/system/DangerZone.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/components/system/DangerZone.jsx
  * @component DangerZone
  * @description Danger zone section for system administration with collection clearing and restoration
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState } from "react";

--- a/frontend/src/components/teams/AddMembersModal.jsx
+++ b/frontend/src/components/teams/AddMembersModal.jsx
@@ -4,7 +4,7 @@
  * @component AddMembersModal
  * @description Modal component for adding existing users to a team
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/components/teams/CreateTeamModal.jsx
+++ b/frontend/src/components/teams/CreateTeamModal.jsx
@@ -4,7 +4,7 @@
  * @component CreateTeamModal
  * @description Modal component for creating new teams with form validation and member invitation
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState } from "react";

--- a/frontend/src/components/teams/InviteMemberModal.jsx
+++ b/frontend/src/components/teams/InviteMemberModal.jsx
@@ -4,7 +4,7 @@
  * @component InviteMemberModal
  * @description Modal component for inviting new members to teams with role assignment
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState } from "react";

--- a/frontend/src/components/teams/MemberCard.jsx
+++ b/frontend/src/components/teams/MemberCard.jsx
@@ -4,7 +4,7 @@
  * @component MemberCard
  * @description Card component for displaying team member information
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { MoreVerticalIcon, UserIcon, CrownIcon, ShieldIcon } from "lucide-react";

--- a/frontend/src/components/teams/TeamBooksTable.jsx
+++ b/frontend/src/components/teams/TeamBooksTable.jsx
@@ -4,7 +4,7 @@
  * @component TeamBooksTable
  * @description Specialized table component for managing books in teams with checkbox selection and bulk actions
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/teams/TeamCard.jsx
+++ b/frontend/src/components/teams/TeamCard.jsx
@@ -4,7 +4,7 @@
  * @component TeamCard
  * @description Team card component displaying team info, member count, project count, and management actions
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/components/teams/TeamDocumentsTable.jsx
+++ b/frontend/src/components/teams/TeamDocumentsTable.jsx
@@ -4,7 +4,7 @@
  * @component TeamDocumentsTable
  * @description Specialized table component for managing documents in teams with checkbox selection and bulk actions
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/teams/TeamProjectsTable.jsx
+++ b/frontend/src/components/teams/TeamProjectsTable.jsx
@@ -4,7 +4,7 @@
  * @component TeamProjectsTable
  * @description Specialized table component for managing projects in teams with checkbox selection and bulk actions
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 

--- a/frontend/src/context/ConfirmationContext.jsx
+++ b/frontend/src/context/ConfirmationContext.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/context/ConfirmationContext.jsx
  * @context ConfirmationContext
  * @description Context provider for confirmation modals
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { createContext, useContext } from 'react';

--- a/frontend/src/context/ThemeContext.jsx
+++ b/frontend/src/context/ThemeContext.jsx
@@ -4,7 +4,7 @@
  * @context ThemeContext
  * @description React context for managing application theme state with persistence and user preferences
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { createContext, useContext, useState, useEffect } from "react";

--- a/frontend/src/hooks/index.js
+++ b/frontend/src/hooks/index.js
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/hooks/index.js
  * @description Centralized export for all custom React hooks
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 

--- a/frontend/src/hooks/useApi.js
+++ b/frontend/src/hooks/useApi.js
@@ -4,7 +4,7 @@
  * @hook useApi
  * @description Custom hook for managing API operations with loading states and error handling
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState, useCallback } from "react";

--- a/frontend/src/hooks/useAutoLogout.jsx
+++ b/frontend/src/hooks/useAutoLogout.jsx
@@ -15,7 +15,7 @@
  *                     Defaults to 15 minutes.
  *
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 // hooks/useAutoLogout.js

--- a/frontend/src/hooks/useConfirmation.js
+++ b/frontend/src/hooks/useConfirmation.js
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/hooks/useConfirmation.js
  * @hook useConfirmation
  * @description Custom hook for handling confirmation modals
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState, useCallback } from 'react';

--- a/frontend/src/hooks/useDocument.js
+++ b/frontend/src/hooks/useDocument.js
@@ -4,7 +4,7 @@
  * @hook useDocument
  * @description Custom hook for loading and managing document data
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState, useEffect, useCallback } from "react";

--- a/frontend/src/hooks/useDocumentManagement.js
+++ b/frontend/src/hooks/useDocumentManagement.js
@@ -4,7 +4,7 @@
  * @hook useDocumentManagement
  * @description Custom hook for managing document selection in book forms
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState, useCallback } from "react";

--- a/frontend/src/hooks/useExternalContacts.js
+++ b/frontend/src/hooks/useExternalContacts.js
@@ -4,7 +4,7 @@
  * @hook useExternalContacts
  * @description Custom hook for managing external contacts in document forms
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState, useCallback } from "react";

--- a/frontend/src/hooks/useFileUpload.js
+++ b/frontend/src/hooks/useFileUpload.js
@@ -4,7 +4,7 @@
  * @hook useFileUpload
  * @description Custom hook for managing file upload state and progress
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState, useCallback } from "react";

--- a/frontend/src/hooks/useFormData.js
+++ b/frontend/src/hooks/useFormData.js
@@ -4,7 +4,7 @@
  * @hook useFormData
  * @description Custom hook for loading common form data (users, categories, external contact types)
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/hooks/useReviewAssignments.js
+++ b/frontend/src/hooks/useReviewAssignments.js
@@ -4,7 +4,7 @@
  * @hook useReviewAssignments
  * @description Custom hook for managing document review assignments and completion status
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState, useEffect, useCallback } from "react";

--- a/frontend/src/hooks/useReviewManagement.js
+++ b/frontend/src/hooks/useReviewManagement.js
@@ -4,7 +4,7 @@
  * @hook useReviewManagement
  * @description Custom hook for managing document review assignments and scheduling
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState, useCallback } from "react";

--- a/frontend/src/hooks/useStakeholderManagement.js
+++ b/frontend/src/hooks/useStakeholderManagement.js
@@ -4,7 +4,7 @@
  * @hook useStakeholderManagement
  * @description Custom hook for managing stakeholders and owners in document forms
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState, useCallback } from "react";

--- a/frontend/src/hooks/useUserRole.js
+++ b/frontend/src/hooks/useUserRole.js
@@ -4,7 +4,7 @@
  * @hook useUserRole
  * @description Custom hook for managing user authentication and role state
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState, useEffect, useCallback } from "react";

--- a/frontend/src/lib/axios.js
+++ b/frontend/src/lib/axios.js
@@ -4,7 +4,7 @@
  * @module AxiosConfig
  * @description Axios HTTP client configuration with base URL, interceptors, and authentication headers
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import axios from "axios";

--- a/frontend/src/lib/documentFormSchema.js
+++ b/frontend/src/lib/documentFormSchema.js
@@ -4,7 +4,7 @@
  * @module documentFormSchema
  * @description Shared validation schemas and constants for document forms
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { z } from "zod";

--- a/frontend/src/lib/globalUtils.js
+++ b/frontend/src/lib/globalUtils.js
@@ -4,7 +4,7 @@
  * @module globalUtils
  * @description Global utility functions for common operations across the application
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 // frontend/src/lib/globalUtils.js

--- a/frontend/src/lib/safeUtils.js
+++ b/frontend/src/lib/safeUtils.js
@@ -4,7 +4,7 @@
  * @module safeUtils
  * @description Safe utility functions to prevent common React errors. These functions ensure data is always in the expected format
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -4,7 +4,7 @@
  * @module utils
  * @description Backend utility functions for object validation and common server-side operations
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 /**

--- a/frontend/src/lib/validation.js
+++ b/frontend/src/lib/validation.js
@@ -4,7 +4,7 @@
  * @module validation
  * @description Form validation utilities with comprehensive validation rules and error handling
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 /**

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { StrictMode } from 'react';

--- a/frontend/src/pages/AdminProjectsPage.jsx
+++ b/frontend/src/pages/AdminProjectsPage.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/pages/AdminProjectsPage.jsx
  * @page AdminProjectsPage
  * @description Admin page for managing all projects in the system
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/AdminTeamsPage.jsx
+++ b/frontend/src/pages/AdminTeamsPage.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/pages/AdminTeamsPage.jsx
  * @page AdminTeamsPage
  * @description Admin page for managing all teams in the system
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/AnalyticsPage.jsx
+++ b/frontend/src/pages/AnalyticsPage.jsx
@@ -4,7 +4,7 @@
  * @page AnalyticsPage
  * @description Analytics dashboard with charts and metrics for document management insights and reporting
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/CreateBookPage.jsx
+++ b/frontend/src/pages/CreateBookPage.jsx
@@ -4,7 +4,7 @@
  * @page CreateBookPage
  * @description Book creation page with form for adding new books using shared design patterns
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState } from "react";

--- a/frontend/src/pages/CreateCatPage.jsx
+++ b/frontend/src/pages/CreateCatPage.jsx
@@ -4,7 +4,7 @@
  * @page CreateCatPage
  * @description Category creation page with form for adding new document categories
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState } from "react";

--- a/frontend/src/pages/CreateDocPage.jsx
+++ b/frontend/src/pages/CreateDocPage.jsx
@@ -4,7 +4,7 @@
  * @page CreateDocPage
  * @description Document creation page with form for uploading files, setting metadata, assigning stakeholders and owners
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useNavigate, Link } from "react-router";

--- a/frontend/src/pages/CreateProjectPage.jsx
+++ b/frontend/src/pages/CreateProjectPage.jsx
@@ -4,7 +4,7 @@
  * @page CreateProjectPage
  * @description Project creation page with form for setting up new projects and team assignments
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/CustomChartsPage.jsx
+++ b/frontend/src/pages/CustomChartsPage.jsx
@@ -4,7 +4,7 @@
  * @page CustomChartPage
  * @description Custom analytics page for creating and viewing personalized data visualizations
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/EditBookPage.jsx
+++ b/frontend/src/pages/EditBookPage.jsx
@@ -4,7 +4,7 @@
  * @page EditBookPage
  * @description Book editing page with form for updating existing books using shared design patterns
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useNavigate, useParams, Link } from "react-router";

--- a/frontend/src/pages/EditCatPage.jsx
+++ b/frontend/src/pages/EditCatPage.jsx
@@ -4,7 +4,7 @@
  * @page EditCatPage
  * @description Category editing page with form for updating existing categories
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/EditDocPage.jsx
+++ b/frontend/src/pages/EditDocPage.jsx
@@ -4,7 +4,7 @@
  * @page EditDocPage
  * @description Document editing page with form validation for updating document metadata, stakeholders, and file versions
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/pages/EditProjectPage.jsx
+++ b/frontend/src/pages/EditProjectPage.jsx
@@ -4,7 +4,7 @@
  * @page EditProjectPage
  * @description Project editing page for updating project details, status, and team members
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/EditTeamPage.jsx
+++ b/frontend/src/pages/EditTeamPage.jsx
@@ -4,7 +4,7 @@
  * @page EditTeamPage
  * @description Team editing page for updating team information and managing member roles
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/ForgotPassPage.jsx
+++ b/frontend/src/pages/ForgotPassPage.jsx
@@ -4,7 +4,7 @@
  * @page ForgotPassPage
  * @description Page component for password reset request functionality
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import React, { useState } from "react";

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -4,7 +4,7 @@
  * @page HomePage
  * @description Main dashboard page displaying document overview, recent documents, and quick access to key features
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -4,7 +4,7 @@
  * @page LoginPage
  * @description Page for user authentication and login.
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 

--- a/frontend/src/pages/ManageExternalContactTypesPage.jsx
+++ b/frontend/src/pages/ManageExternalContactTypesPage.jsx
@@ -4,7 +4,7 @@
  * @page ManageExternalContactTypesPage
  * @description External contact type management page for organizing contact categories
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/pages/MyProfilePage.jsx
+++ b/frontend/src/pages/MyProfilePage.jsx
@@ -4,7 +4,7 @@
  * @page MyProfilePage
  * @description User profile management page for updating personal information and preferences
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/pages/ProjectDetailPage.jsx
+++ b/frontend/src/pages/ProjectDetailPage.jsx
@@ -4,7 +4,7 @@
  * @page ProjectDetailPage
  * @description Project detail page showing project information, documents, and team collaboration
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/pages/ProjectSettingsPage.jsx
+++ b/frontend/src/pages/ProjectSettingsPage.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/pages/ProjectSettingsPage.jsx
  * @page ProjectSettingsPage
  * @description Project settings page for managing project configuration and preferences
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/ProjectsPage.jsx
+++ b/frontend/src/pages/ProjectsPage.jsx
@@ -4,7 +4,7 @@
  * @page ProjectsPage
  * @description Project management page with filtering, search, and project creation for organizing documents by project
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/pages/RegUserPage.jsx
+++ b/frontend/src/pages/RegUserPage.jsx
@@ -4,7 +4,7 @@
  * @page RegUserPage
  * @description User registration page with form validation and account creation functionality
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState } from "react";

--- a/frontend/src/pages/ResetPassPage.jsx
+++ b/frontend/src/pages/ResetPassPage.jsx
@@ -4,7 +4,7 @@
  * @page ResetPassPage
  * @description Password reset page for updating user passwords with secure token validation
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 // ResetPasswordForm.jsx

--- a/frontend/src/pages/SystemInfoPage.jsx
+++ b/frontend/src/pages/SystemInfoPage.jsx
@@ -4,7 +4,7 @@
  * @page SystemInfoPage
  * @description System information dashboard displaying server status, database info, and application metrics
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/pages/TeamDetailPage.jsx
+++ b/frontend/src/pages/TeamDetailPage.jsx
@@ -4,7 +4,7 @@
  * @page TeamDetailPage
  * @description Team detail page displaying team members, projects, and collaboration tools
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/pages/TeamSettingsPage.jsx
+++ b/frontend/src/pages/TeamSettingsPage.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/pages/TeamSettingsPage.jsx
  * @page TeamSettingsPage
  * @description Team settings page for managing team configuration and preferences
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/TeamsPage.jsx
+++ b/frontend/src/pages/TeamsPage.jsx
@@ -4,7 +4,7 @@
  * @page TeamsPage
  * @description Team management page displaying user teams with creation, editing, and member management capabilities
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/pages/ViewBookPage.jsx
+++ b/frontend/src/pages/ViewBookPage.jsx
@@ -4,7 +4,7 @@
  * @page ViewBookPage
  * @description Individual book view page showing book details and contained documents
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/ViewBooksPage.jsx
+++ b/frontend/src/pages/ViewBooksPage.jsx
@@ -4,7 +4,7 @@
  * @page ViewBooksPage
  * @description Books listing page with filtering and management capabilities
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import React, { useState, useEffect } from 'react';

--- a/frontend/src/pages/ViewCatsPage.jsx
+++ b/frontend/src/pages/ViewCatsPage.jsx
@@ -4,7 +4,7 @@
  * @page ViewCatsPage
  * @description Category management page for viewing, creating, and organizing document categories
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/pages/ViewDocPage.jsx
+++ b/frontend/src/pages/ViewDocPage.jsx
@@ -4,7 +4,7 @@
  * @page ViewDocPage
  * @description Document detail page displaying document information, version history, file downloads, and review management
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { Link, useNavigate, useParams } from "react-router";

--- a/frontend/src/pages/ViewDocsPage.jsx
+++ b/frontend/src/pages/ViewDocsPage.jsx
@@ -4,7 +4,7 @@
  * @page ViewDocsPage
  * @description Document listing page with search, filtering, sorting, and bulk operations for managing documents
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/pages/ViewUserPage.jsx
+++ b/frontend/src/pages/ViewUserPage.jsx
@@ -4,7 +4,7 @@
  * @page ViewUserPage
  * @description User detail page displaying user information and administrative actions
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/pages/ViewUsersPage.jsx
+++ b/frontend/src/pages/ViewUsersPage.jsx
@@ -4,7 +4,7 @@
  * @page ViewUsersPage
  * @description User management page with filtering, search, and user administration for system administrators
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/themes.js
+++ b/frontend/src/themes.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 // Theme definitions for the application

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rd-docman",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rd-docman",
-      "version": "2.2.3",
+      "version": "2.2.4",
       "license": "UNLICENSED",
       "devDependencies": {
         "@playwright/test": "^1.42.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rdocman",
   "private": true,
-  "version": "2.2.3",
+  "version": "2.2.4",
   "type": "module",
   "description": "RDocMan is a document management application for all sorts of documents. Track updates, schedule reviews, categorize, and upload versions of your docs. DocMan hopes to be the most comprehensive piece of software to manage all of your documentation. You can schedule your documentation for review between stakeholders, the original authors, contributors, relevant tech leads, etc... Categorize, analyze, version repositories, and basically everything you would need to keep your documentation well organized, maintained, analyzed, and backed up.",
   "keywords": [

--- a/project-config.json
+++ b/project-config.json
@@ -1,5 +1,5 @@
 {
   "author": "Richard Bakos",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "license": "UNLICENSED"
 }

--- a/scripts/apache_production_deploy.sh
+++ b/scripts/apache_production_deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 # ==================================================
 # === DocMan Production Deployment Script (Full) ===
@@ -36,10 +36,20 @@ set -e
 # GitHub: https://github.com/resonance-designs
 # Date: 2025-09-24
 
+DEPLOY_ROOT=/var/www/docman
+BACKEND_DIR="$DEPLOY_ROOT/backend"
+VUE_FRONTEND_DIR="$DEPLOY_ROOT/frontend-vue"
+APACHE_ROOT=/var/www/html
+SERVICE_FILE=/etc/systemd/system/docman-backend.service
+SERVICE_USER=docman
+SERVICE_GROUP=www-data
+MIN_NODE_VERSION=20.19.0
+ENV_SOURCE_FILE=""
+
 # --- Functions ---
 rollback() {
     echo "⚠️ Rolling back deployment..."
-    rm -rf /var/www/docman
+    rm -rf "$DEPLOY_ROOT"
     echo "Deployment has been successfully reversed."
     exit 0
 }
@@ -54,9 +64,124 @@ ask() {
     sed -i "s|^$var_name=.*|$var_name=$value|" .env.prod
 }
 
+detect_previous_env_source() {
+    local candidates=()
+    local latest_backup
+
+    if [[ -f "$BACKEND_DIR/.env.prod" ]]; then
+        ENV_SOURCE_FILE="$BACKEND_DIR/.env.prod"
+        return
+    fi
+
+    latest_backup=$(ls -dt /var/www/docman_bak_* 2>/dev/null | head -n1 || true)
+    if [[ -n "$latest_backup" && -f "$latest_backup/backend/.env.prod" ]]; then
+        ENV_SOURCE_FILE="$latest_backup/backend/.env.prod"
+        return
+    fi
+
+    ENV_SOURCE_FILE=""
+}
+
+env_default() {
+    local var_name="$1"
+    local fallback="${2:-}"
+
+    if [[ -n "$ENV_SOURCE_FILE" && -f "$ENV_SOURCE_FILE" ]]; then
+        local value
+        value=$(grep -E "^${var_name}=" "$ENV_SOURCE_FILE" | tail -n1 | cut -d= -f2- || true)
+        if [[ -n "$value" && "$value" != "null" ]]; then
+            echo "$value"
+            return
+        fi
+    fi
+
+    echo "$fallback"
+}
+
 mask_sensitive() {
     local var_value="$1"
     [[ -z "$var_value" ]] && echo "null" || echo "${var_value:0:3}***"
+}
+
+version_ge() {
+    local current="$1"
+    local minimum="$2"
+    [[ "$(printf '%s\n%s\n' "$minimum" "$current" | sort -V | head -n1)" == "$minimum" ]]
+}
+
+detect_existing_mongo_setup() {
+    [[ -f /etc/mongod.conf ]]
+}
+
+read_existing_mongo_value() {
+    local pattern="$1"
+    awk -F': ' "$pattern {print \$2; exit}" /etc/mongod.conf 2>/dev/null
+}
+
+backup_if_exists() {
+    local target="$1"
+    if [[ -e "$target" ]]; then
+        local backup_path="${target}_bak_$(date +%F_%H%M%S)"
+        echo "⚠️ Existing path detected at $target"
+        echo "🔄 Backing it up to $backup_path"
+        mv "$target" "$backup_path"
+    fi
+}
+
+ensure_service_user() {
+    if id "$SERVICE_USER" >/dev/null 2>&1; then
+        echo "✅ Service user '$SERVICE_USER' already exists."
+        return
+    fi
+
+    echo "🔧 Creating service user '$SERVICE_USER'..."
+    useradd --system --create-home --home-dir "$DEPLOY_ROOT" --gid "$SERVICE_GROUP" --shell /usr/sbin/nologin "$SERVICE_USER"
+}
+
+write_backend_service() {
+    if [[ -f "$SERVICE_FILE" ]]; then
+        cp "$SERVICE_FILE" "${SERVICE_FILE}.bak.$(date +%F_%H%M%S)"
+        rm -f "$SERVICE_FILE"
+    fi
+
+    cat <<EOL > "$SERVICE_FILE"
+[Unit]
+Description=RDocMan Backend
+After=network.target
+
+[Service]
+WorkingDirectory=$BACKEND_DIR
+Environment=NODE_ENV=production
+Environment=ATLAS=no
+EnvironmentFile=$BACKEND_DIR/.env.prod
+ExecStart=/usr/bin/npm run prod
+User=$SERVICE_USER
+Group=$SERVICE_GROUP
+Restart=always
+RestartSec=3
+ExecStartPre=/usr/bin/install -d -o $SERVICE_GROUP -g $SERVICE_GROUP -m 775 $BACKEND_DIR/uploads
+NoNewPrivileges=true
+AmbientCapabilities=
+PrivateTmp=true
+ProtectSystem=full
+ReadWritePaths=$BACKEND_DIR
+
+[Install]
+WantedBy=multi-user.target
+EOL
+}
+
+publish_frontend_assets() {
+    local frontend_folder="$1"
+    local publish_root="$APACHE_ROOT/$frontend_folder"
+
+    mkdir -p "$publish_root/public_html"
+    mkdir -p "$publish_root/public_html/remote"
+    mkdir -p "$publish_root/logs"
+
+    rsync -a --delete "$VUE_FRONTEND_DIR/dist/" "$publish_root/public_html/"
+    rsync -a --delete "$VUE_FRONTEND_DIR/dist-remote/remote/" "$publish_root/public_html/remote/"
+    chown -R www-data:www-data "$publish_root/public_html"
 }
 
 check_prerequisites() {
@@ -64,12 +189,11 @@ check_prerequisites() {
     echo "🔍 Checking prerequisites..."
     missing_packages=()
 
-    # Node.js (>=18)
+    # Node.js (>=20.19.0 for current Vite/Vuetify toolchain)
     if command -v node >/dev/null 2>&1; then
         NODE_VERSION=$(node -v | sed 's/v//')
-        NODE_MAJOR=$(echo $NODE_VERSION | cut -d. -f1)
-        if [[ $NODE_MAJOR -lt 18 ]]; then
-            echo "⚠️ Node.js $NODE_VERSION found (need >= 18)."
+        if ! version_ge "$NODE_VERSION" "$MIN_NODE_VERSION"; then
+            echo "⚠️ Node.js $NODE_VERSION found (need >= $MIN_NODE_VERSION)."
             missing_packages+=("nodejs" "npm")
         else
             echo "✅ Node.js $NODE_VERSION installed."
@@ -101,6 +225,14 @@ check_prerequisites() {
         missing_packages+=("netcat-openbsd")
     else
         echo "✅ Netcat installed."
+    fi
+
+    # rsync
+    if ! command -v rsync >/dev/null 2>&1; then
+        echo "⚠️ rsync not found."
+        missing_packages+=("rsync")
+    else
+        echo "✅ rsync installed."
     fi
 
     # UFW (mandatory)
@@ -141,9 +273,9 @@ echo ""
 echo "This script deploys DocMan to a production server running Apache."
 echo ""
 echo "It performs the following steps:"
-echo "  1. Checks prerequisites (Node.js, Apache, UFW, Certbot)."
-echo "  2. Clones the repository from GitHub."
-echo "  3. Installs dependencies and builds the application using npm."
+echo "  1. Checks prerequisites (Node.js >= $MIN_NODE_VERSION, Apache, UFW, Certbot)."
+echo "  2. Clones a fresh repository checkout from GitHub."
+echo "  3. Installs dependencies, builds the Vue frontend, and builds the remote desktop bundle."
 echo "  4. Prepares the environment by setting up MongoDB configurations,"
 echo "     including TLS/SSL settings if desired."
 echo "  5. Configures other essential environment variables such as Node.js port,"
@@ -151,10 +283,11 @@ echo "     Redis, JWT keys, and AWS SES credentials."
 echo "  6. Provides a summary of the final configuration before proceeding further."
 echo "  7. Prompts the user to review their configuration before proceeding."
 echo "  8. Starts the MongoDB service and waits until it's ready."
-echo "  9. Creates a systemd service unit for DocMan."
+echo "  9. Recreates an idempotent systemd service unit for DocMan."
 echo " 10. Enables and starts the DocMan service."
-echo " 11. Generates letsencrypt SSL/TLS certificates with certbot for HTTPS support."
-echo " 12. Configures Apache virtual hosts for HTTP and HTTPS redirection."
+echo " 11. Publishes the Vue frontend and remote bundle to Apache."
+echo " 12. Generates letsencrypt SSL/TLS certificates with certbot for HTTPS support."
+echo " 13. Configures Apache virtual hosts for HTTP and HTTPS redirection."
 echo " 13. Restarts Apache to apply changes."
 echo " 14. Displays a success message upon completion."
 echo ""
@@ -175,23 +308,27 @@ check_prerequisites
 # --- 1️⃣ Clone repository ---
 echo ""
 echo "1️⃣ Cloning repository..."
-rm -rf /var/www/docman
-mkdir -p /var/www/docman
-chown -R www-data:www-data /var/www/docman
-git clone https://github.com/resonance-designs/docman.git /var/www/docman
+detect_previous_env_source
+backup_if_exists "$DEPLOY_ROOT"
+mkdir -p "$DEPLOY_ROOT"
+chown -R "$SERVICE_GROUP:$SERVICE_GROUP" "$DEPLOY_ROOT"
+git clone https://github.com/resonance-designs/docman.git "$DEPLOY_ROOT"
 echo "✅ Repository cloned."
 
 # --- 2️⃣ Install dependencies & build ---
 echo ""
 echo "2️⃣ Installing dependencies & building app..."
-cd /var/www/docman
-npm run build
-echo "✅ Build complete."
+cd "$DEPLOY_ROOT"
+npm ci --prefix backend
+npm ci --include=dev --prefix frontend-vue
+npm run build --prefix frontend-vue
+npm run build:remote --prefix frontend-vue
+echo "✅ Vue frontend and remote bundle build complete."
 
 # --- 3️⃣ Prepare environment ---
 echo ""
 echo "3️⃣ Configuring environment..."
-cd backend
+cd "$BACKEND_DIR"
 cp .env.sample .env.prod
 sed -i '/^#/d;/^$/d' .env.prod
 sed -i 's/^ACTIVE_ENV=.*/ACTIVE_ENV=1/' .env.prod
@@ -203,17 +340,55 @@ echo ""
 echo "4️⃣ MongoDB Setup:"
 echo "1) Private MongoDB server (localhost/own host)"
 echo "2) MongoDB Atlas"
-read -p "Choose your MongoDB type [1/2]: " mongo_choice
+existing_mongo_reuse=false
+if detect_existing_mongo_setup; then
+    echo "✅ Existing /etc/mongod.conf detected."
+    read -p "Reuse the existing local MongoDB server configuration instead of regenerating it? (Y/n): " reuse_mongo
+    if [[ ! "$reuse_mongo" =~ ^[Nn]$ ]]; then
+        mongo_choice="1"
+        existing_mongo_reuse=true
+    fi
+fi
+
+if [[ -z "${mongo_choice:-}" ]]; then
+    read -p "Choose your MongoDB type [1/2]: " mongo_choice
+fi
 
 if [[ "$mongo_choice" == "1" ]]; then
     # --- Private MongoDB Configuration ---
-    ask "MONGO_USER" "Enter MongoDB username" ""
-    ask "MONGO_PASSWORD" "Enter MongoDB password" ""
-    ask "MONGO_HOST" "Enter MongoDB host (IP/hostname)" "localhost"
-    ask "MONGO_PORT" "Enter MongoDB port" "27017"
+    existing_mongo_port="27017"
+    existing_mongo_tls="false"
+    existing_mongo_ca_file="/etc/mongodb-ssl/ca/mongodb-ca.crt"
+    existing_mongo_client_file="/etc/mongodb-ssl/client.pem"
+
+    if [[ "$existing_mongo_reuse" == true ]]; then
+        existing_mongo_port=$(read_existing_mongo_value '/^[[:space:]]+port:/')
+        [[ -z "$existing_mongo_port" ]] && existing_mongo_port="27017"
+
+        if grep -q 'mode: requireTLS' /etc/mongod.conf 2>/dev/null; then
+            existing_mongo_tls="true"
+        fi
+
+        detected_ca_file=$(read_existing_mongo_value '/^[[:space:]]+CAFile:/')
+        [[ -n "$detected_ca_file" ]] && existing_mongo_ca_file="$detected_ca_file"
+
+        echo "🔍 Reusing existing MongoDB server config from /etc/mongod.conf"
+        echo "   port: $existing_mongo_port"
+        echo "   TLS enabled: $existing_mongo_tls"
+    fi
+
+    if [[ -n "$ENV_SOURCE_FILE" ]]; then
+        echo "🔍 Found previous DocMan environment file at $ENV_SOURCE_FILE"
+        echo "   Reusing its values as the default prompts for the new .env.prod"
+    fi
+
+    ask "MONGO_USER" "Enter MongoDB username" "$(env_default MONGO_USER "")"
+    ask "MONGO_PASSWORD" "Enter MongoDB password" "$(env_default MONGO_PASSWORD "")"
+    ask "MONGO_HOST" "Enter MongoDB host (IP/hostname)" "$(env_default MONGO_HOST "localhost")"
+    ask "MONGO_PORT" "Enter MongoDB port" "$(env_default MONGO_PORT "$existing_mongo_port")"
     MONGO_PORT=$(grep "^MONGO_PORT=" .env.prod | cut -d= -f2-)
-    ask "MONGO_DB" "Enter MongoDB database name" ""
-    ask "MONGO_AUTH_SOURCE" "Enter MongoDB auth source (usually 'admin')" "admin"
+    ask "MONGO_DB" "Enter MongoDB database name" "$(env_default MONGO_DB "")"
+    ask "MONGO_AUTH_SOURCE" "Enter MongoDB auth source (usually 'admin')" "$(env_default MONGO_AUTH_SOURCE "admin")"
 
     # Disable Atlas
     sed -i "s|^MONGO_ATLAS_USER=.*|MONGO_ATLAS_USER=null|" .env.prod
@@ -222,18 +397,31 @@ if [[ "$mongo_choice" == "1" ]]; then
     sed -i "s|^MONGO_ATLAS_DB=.*|MONGO_ATLAS_DB=null|" .env.prod
     sed -i "s|^MONGO_ATLAS_APP=.*|MONGO_ATLAS_APP=null|" .env.prod
 
-    # --- Mongo TLS/SSL Setup ---
-    echo ""
-    echo "⚠️ TLS/SSL Warning:"
-    echo "If you choose to enable TLS, the script will generate CA and Mongo certificates for secure connections."
-    echo "Canceling at this step will remove the cloned repo."
-    echo ""
-    echo "1) Proceed with TLS"
-    echo "2) Proceed without TLS"
-    echo "3) Cancel deployment"
-    read -p "Choose an option [1/2/3]: " tls_choice
+    if [[ "$existing_mongo_reuse" == true ]]; then
+        if [[ "$existing_mongo_tls" == "true" ]]; then
+            sed -i "s|^MONGO_TLS=.*|MONGO_TLS=true|" .env.prod
+            ask "MONGO_CA_FILE" "Path to Mongo CA file" "$existing_mongo_ca_file"
+            ask "MONGO_CERT_FILE" "Path to Mongo client PEM" "$existing_mongo_client_file"
+            echo "✅ Reusing existing MongoDB TLS/SSL configuration."
+        else
+            sed -i "s|^MONGO_TLS=.*|MONGO_TLS=false|" .env.prod
+            sed -i "s|^MONGO_CA_FILE=.*|MONGO_CA_FILE=null|" .env.prod
+            sed -i "s|^MONGO_CERT_FILE=.*|MONGO_CERT_FILE=null|" .env.prod
+            echo "✅ Reusing existing MongoDB configuration without TLS/SSL."
+        fi
+    else
+        # --- Mongo TLS/SSL Setup ---
+        echo ""
+        echo "⚠️ TLS/SSL Warning:"
+        echo "If you choose to enable TLS, the script will generate CA and Mongo certificates for secure connections."
+        echo "Canceling at this step will remove the cloned repo."
+        echo ""
+        echo "1) Proceed with TLS"
+        echo "2) Proceed without TLS"
+        echo "3) Cancel deployment"
+        read -p "Choose an option [1/2/3]: " tls_choice
 
-    case $tls_choice in
+        case $tls_choice in
         1)
             # --- Prompt for subject details ---
             read -p "CA Country (C) [US]: " CA_C; CA_C=${CA_C:-US}
@@ -424,7 +612,8 @@ EOF
             echo "Invalid choice. Canceling deployment."
             rollback
             ;;
-    esac
+        esac
+    fi
 
 elif [[ "$mongo_choice" == "2" ]]; then
     # --- MongoDB Atlas Configuration ---
@@ -451,29 +640,29 @@ fi
 # --- 5️⃣ Configure remaining environment ---
 echo ""
 echo "5️⃣ Configuring Node.js port, Redis, JWT, and AWS SES..."
-ask "NODE_PORT" "Enter Node.js port" "5001"
+ask "NODE_PORT" "Enter Node.js port" "$(env_default NODE_PORT "5001")"
 NODE_PORT=$(grep "^NODE_PORT=" .env.prod | cut -d= -f2-)
 
 # Redis
 read -p "Do you want to use Redis? (y/n): " use_redis
 if [[ "$use_redis" =~ ^[Yy]$ ]]; then
-    ask "UPSTASH_REDIS_REST_URL" "Enter Redis REST URL" ""
-    ask "UPSTASH_REDIS_REST_TOKEN" "Enter Redis REST token" ""
+    ask "UPSTASH_REDIS_REST_URL" "Enter Redis REST URL" "$(env_default UPSTASH_REDIS_REST_URL "")"
+    ask "UPSTASH_REDIS_REST_TOKEN" "Enter Redis REST token" "$(env_default UPSTASH_REDIS_REST_TOKEN "")"
 else
     sed -i "s|^UPSTASH_REDIS_REST_URL=.*|UPSTASH_REDIS_REST_URL=null|" .env.prod
     sed -i "s|^UPSTASH_REDIS_REST_TOKEN=.*|UPSTASH_REDIS_REST_TOKEN=null|" .env.prod
 fi
 
 # Authentication
-ask "TOKEN_KEY" "Enter authentication token key (JWT secret)" ""
+ask "TOKEN_KEY" "Enter authentication token key (JWT secret)" "$(env_default TOKEN_KEY "")"
 
 # AWS SES
 read -p "Do you want to use AWS SES for email? (y/n): " use_ses
 if [[ "$use_ses" =~ ^[Yy]$ ]]; then
-    ask "AWS_ACCESS_KEY_ID" "Enter AWS Access Key ID" ""
-    ask "AWS_SECRET_ACCESS_KEY" "Enter AWS Secret Access Key" ""
-    ask "AWS_SES_REGION" "Enter AWS SES region (e.g. us-east-1)" ""
-    ask "AWS_SES_SENDER_EMAIL" "Enter AWS SES sender email" ""
+    ask "AWS_ACCESS_KEY_ID" "Enter AWS Access Key ID" "$(env_default AWS_ACCESS_KEY_ID "")"
+    ask "AWS_SECRET_ACCESS_KEY" "Enter AWS Secret Access Key" "$(env_default AWS_SECRET_ACCESS_KEY "")"
+    ask "AWS_SES_REGION" "Enter AWS SES region (e.g. us-east-1)" "$(env_default AWS_SES_REGION "")"
+    ask "AWS_SES_SENDER_EMAIL" "Enter AWS SES sender email" "$(env_default AWS_SES_SENDER_EMAIL "")"
 else
     sed -i "s|^AWS_ACCESS_KEY_ID=.*|AWS_ACCESS_KEY_ID=null|" .env.prod
     sed -i "s|^AWS_SECRET_ACCESS_KEY=.*|AWS_SECRET_ACCESS_KEY=null|" .env.prod
@@ -531,7 +720,11 @@ if [[ "$mongo_choice" == "1" ]]; then
 fi
 
 # --- 8️⃣ Create MongoDB Admin User ---
-read -p "8️⃣ Do you want to create a MongoDB admin user automatically? (y/n): " create_admin
+if [[ "$existing_mongo_reuse" == true ]]; then
+    read -p "8️⃣ Existing MongoDB detected. Do you want to create another MongoDB admin user automatically anyway? (y/n): " create_admin
+else
+    read -p "8️⃣ Do you want to create a MongoDB admin user automatically? (y/n): " create_admin
+fi
 if [[ "$create_admin" =~ ^[Yy]$ ]]; then
     mongo <<EOF
 use admin
@@ -545,63 +738,38 @@ EOF
 fi
 
 # --- 9️⃣ Systemd Backend Service ---
-SERVICE_FILE=/etc/systemd/system/docman-backend.service
 echo ""
 echo "9️⃣ Creating systemd service file at $SERVICE_FILE..."
-cat <<EOL > "$SERVICE_FILE"
-[Unit]
-Description=DocMan Backend
-After=network.target
-
-[Service]
-WorkingDirectory=/var/www/docman/backend
-Environment=NODE_ENV=production
-Environment=ATLAS=no
-EnvironmentFile=/var/www/docman/backend/.env.prod
-ExecStart=/usr/bin/npm run prod
-User=root
-Group=www-data
-Restart=always
-RestartSec=3
-ExecStartPre=/usr/bin/install -d -o www-data -g www-data -m 775 /var/www/docman/backend/uploads
-NoNewPrivileges=true
-AmbientCapabilities=
-PrivateTmp=true
-ProtectSystem=full
-ReadWritePaths=/var/www/docman/backend
-
-[Install]
-WantedBy=multi-user.target
-EOL
-
+ensure_service_user
+chown -R "$SERVICE_USER:$SERVICE_GROUP" "$BACKEND_DIR"
+install -d -o "$SERVICE_GROUP" -g "$SERVICE_GROUP" -m 775 "$BACKEND_DIR/uploads"
+write_backend_service
 systemctl daemon-reload
 systemctl enable docman-backend.service
 systemctl start docman-backend.service
 echo "✅ DocMan Backend service created and started successfully."
 
-# --- 1️⃣0️⃣ Apache frontend ---
+# --- 1️⃣0️⃣ Apache frontend and remote bundle ---
 echo ""
 echo "1️⃣0️⃣ Setting up Apache frontend with reverse proxy..."
-read -p "Enter folder/domain name for frontend: " frontend_folder
+read -p "Enter folder name for frontend publish root [docman]: " frontend_folder
+frontend_folder=${frontend_folder:-docman}
+backup_if_exists "$APACHE_ROOT/$frontend_folder"
 # Create frontend directory structure
-mkdir -p /var/www/html/$frontend_folder
-mkdir -p /var/www/html/$frontend_folder/public_html
-mkdir -p /var/www/html/$frontend_folder/logs
-# Copy files from dist to apache frontend & set permissions
-rsync -a --delete /var/www/docman/frontend/dist/ /var/www/html/$frontend_folder/public_html/
-chown -R www-data:www-data /var/www/html/$frontend_folder/public_html
+publish_frontend_assets "$frontend_folder"
 # Enable Apache modules
 a2enmod proxy proxy_http rewrite headers
 # Create Apache config file
-read -p "Enter Apache site name (conf file name, e.g. docman): " site_name
+read -p "Enter Apache site name (conf file name) [docman]: " site_name
+site_name=${site_name:-docman}
 read -p "Enter domain name for ServerName (e.g. docman.resonancedesigns.dev): " domain_name
 
 sudo tee /etc/apache2/sites-available/$site_name.conf >/dev/null <<EOF
 <VirtualHost *:80>
     ServerName $domain_name
-    DocumentRoot /var/www/html/$frontend_folder/public_html/
+    DocumentRoot $APACHE_ROOT/$frontend_folder/public_html/
 
-    <Directory /var/www/html/$frontend_folder/public_html/>
+    <Directory $APACHE_ROOT/$frontend_folder/public_html/>
         Options FollowSymLinks
         AllowOverride All
         Require all granted

--- a/scripts/security-audit.js
+++ b/scripts/security-audit.js
@@ -4,7 +4,7 @@
  * @script security-audit
  * @description Automated security audit script for dependency scanning and vulnerability detection
  * @author Richard Bakos
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 import { execSync } from 'child_process';

--- a/scripts/update-tests.js
+++ b/scripts/update-tests.js
@@ -4,7 +4,7 @@
  * @file /docman/scripts/update-tests.js
  * @description Script to analyze and update test files to ensure compatibility with current codebase
  * @author DocMan Team
- * @version 2.2.3
+ * @version 2.2.4
  * @license UNLICENSED
  */
 


### PR DESCRIPTION
## Summary

Prepares DocMan for suite-level Authentik authentication while updating the production deployment path for the current Vue/Vuetify architecture.

## Changes

- Added Authentik migration architecture documentation in `docs/architecture/ADR-005-suite-identity-migration.md`.
- Added backend identity resolution support for future Authentik-issued tokens.
- Added `authentikSub` and provider-linking support to the local DocMan user model.
- Added admin/CLI workflows for linking existing DocMan users to Authentik identities.
- Added Authentik PKCE login support in the Vue frontend.
- Updated `apache_production_deploy.sh` for the current RDocMan deployment architecture.
- Updated deployment flow to build and publish `frontend-vue`.
- Added support for publishing the Vue remote bundle for the RDSysCMD hybrid desktop module.
- Updated deployment defaults, service-user handling, MongoDB reuse detection, and `.env.prod` prompt reuse.
- Updated README, architecture docs, changelog, and version metadata for `2.2.4`.

## Notes

- This is release branch `release/2.2.4`.
- The branch also includes the GitHub Pages workflow correction that requires Pages to be enabled manually in repository settings.