### PR TITLE
Release v2.2.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ docman.users.json
 certs/
 
 db/
+
+.secrets/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.5] - 2026-04-29
+
+### Added
+
+- Added `.secrets/.env.prod` as a local ignored production env reference for recovery and deployment patching.
+- Added `AUTHENTIK_JWKS_URL` support so the backend can verify Authentik RS256 tokens from JWKS instead of relying solely on a hard-coded PEM.
+
+### Changed
+
+- Updated `apache_production_deploy.sh` to preserve discovered `.env*` files under `~/docman/env-backups/` and keep `~/docman/previous-backend.env.prod` as the preferred recovery source.
+- Changed the deployment script to detect and reuse existing production values more safely during recovery prompts instead of depending on placeholder `.env` content.
+- Modernized `apache_production_update.sh` to rebuild the Vue frontend, publish the remote bundle, preserve prior env files, and follow the current `docman` service model.
+- Modernized `apache_production_update_ni.sh` to match the current Vue/remote-bundle deployment path, preserve env backups, and require explicit SSL domain/email inputs for Certbot automation.
+- Updated deployment documentation and README guidance to reflect the current Linode, Apache, Authentik, SES, Redis, and hybrid remote-bundle deployment path.
+- Updated backend Authentik configuration examples and `.env.sample` to prefer JWKS-based validation with `AUTHENTIK_JWKS_URL`.
+- Updated Swagger/OpenAPI metadata to use `info@resonancedesigns.dev`, label the live API correctly as production, and remove stale `docman.com` assumptions.
+- Updated package metadata and backend email fallbacks to use the Resonance Designs contact address consistently.
+
 ## [0.2.4] - 2026-04-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -182,8 +182,8 @@ Download them and then upload them somewhere on your server, like your users hom
 | Script | Purpose | Notes |
 |--------|---------|------|
 | [`apache_production_deploy.sh`](https://github.com/resonance-designs/docman/releases/download/latest/apache_production_deploy.sh) | Initial deployment of DocMan to a fresh server | Use this for first-time setup or to recover a broken deployment tree. Clones a fresh repo copy, rebuilds the Vue frontend, publishes the remote bundle, and recreates the backend service definition. |
-| [`apache_production_update.sh`](https://github.com/resonance-designs/docman/releases/download/latest/apache_production_update.sh) | Standard interactive update | Updates an existing production instance. Prompts for confirmations. Optional SSL update. |
-| [`apache_production_update_ni.sh`](https://github.com/resonance-designs/docman/releases/download/latest/apache_production_update_ni.sh) | Non-interactive automated update | Fully automated update without prompts. Supports optional SSL and `--dry-run` for testing. Automatically rolls back on errors. |
+| [`apache_production_update.sh`](https://github.com/resonance-designs/docman/releases/download/latest/apache_production_update.sh) | Standard interactive update | Updates an existing Apache-hosted instance using the current Vue frontend and remote-bundle publish path. Preserves the previous backend env, republishes the hybrid assets, and optionally runs Certbot for one or more domains. |
+| [`apache_production_update_ni.sh`](https://github.com/resonance-designs/docman/releases/download/latest/apache_production_update_ni.sh) | Non-interactive automated update | Fully automated update for the current Vue/remote-bundle deployment shape. Supports `--dry-run`, auto-rolls back on errors, and can run Certbot when `SSL_DOMAINS` and `CERTBOT_EMAIL` are provided. |
 
 ### Setting Executable Permissions
 
@@ -206,11 +206,25 @@ sudo ./apache_production_deploy.sh
 ```
 
 * Installs backend and frontend on a fresh server.
-* Sets up environment variables (`.env.prod`) from `.env.sample.`
+* Creates a fresh `.env.prod` from `.env.sample` for the new deployment.
 * Optionally sets up SSL certificates.
 * Clones a fresh repository checkout into `/var/www/docman`.
 * Builds `frontend-vue` and `frontend-vue/dist-remote/remote/`.
 * Republishes the remote bundle used by `RDSysCMD`.
+* Backs up an existing `/var/www/docman` tree before replacing it.
+* Exports previously discovered `.env*` files to `~/docman/env-backups/`.
+* Preserves the previous backend environment file at `~/docman/previous-backend.env.prod` when available.
+* Reuses the preserved backend env file as the preferred source of prompt defaults on the next recovery run.
+
+If you are recovering a broken Linode deployment rather than deploying to a brand-new server, expect the script to remain interactive. It may still ask for:
+
+* MongoDB connection values
+* `NODE_PORT`
+* Upstash Redis values
+* AWS SES values
+* JWT/auth token secret values
+
+The preserved env file under `~/docman/previous-backend.env.prod` is intended to make those prompts much less painful on the next run.
 
 #### 2️⃣ Standard Interactive Update
 
@@ -218,8 +232,13 @@ sudo ./apache_production_deploy.sh
 sudo ./apache_production_update.sh
 ```
 
-* Updates DocMan in an interactive mode.
-* Prompts for confirmation before critical steps.
+* Updates an existing Apache-hosted DocMan instance in an interactive mode.
+* Preserves the previous `.env.prod` before replacing `/var/www/docman`.
+* Exports discovered `.env*` files into `~/docman/env-backups/`.
+* Builds the current `frontend-vue` app and `dist-remote/remote/`.
+* Republishes both the browser UI and the hybrid remote bundle.
+* Restarts the backend service and reloads Apache.
+* Can optionally run Certbot for one or more domains.
 
 #### 3️⃣ Non-Interactive Update
 
@@ -227,11 +246,15 @@ sudo ./apache_production_update.sh
 sudo ./apache_production_update_ni.sh [--ssl] [--dry-run]
 ```
 
-* Performs a fully automated, non-interactive update.
-* `--ssl` – Updates SSL certificates.
-* `--dry-run` – Simulates the update without making any changes.
-* Automatically rolls back changes if any command fails.
-* Backs up `.env.prod` and frontend files at `/tmp/docman_env_backup/`.
+* Performs a fully automated update of the current Vue/remote-bundle deployment shape.
+* Preserves `.env.prod` and exports previous `.env*` files before replacing `/var/www/docman`.
+* Rebuilds the Vue frontend and the remote bundle.
+* Republishes frontend assets into the Apache publish root.
+* Automatically rolls back if any command fails.
+* `--dry-run` simulates the update without applying changes.
+* `--ssl` enables Certbot, but expects these environment variables to be set first:
+  * `SSL_DOMAINS`
+  * `CERTBOT_EMAIL`
 
 ### Recommended Workflow
 
@@ -244,7 +267,7 @@ sudo ./apache_production_update_ni.sh [--ssl] [--dry-run]
 3. Then run the actual non-interactive update:
 
    ```bash
-   sudo ./apache_production_update_ni.sh --ssl
+   SSL_DOMAINS="docman.resonancedesigns.dev api.docman.resonancedesigns.dev" CERTBOT_EMAIL="info@resonancedesigns.dev" sudo ./apache_production_update_ni.sh --ssl
    ```
 
    or
@@ -257,7 +280,7 @@ sudo ./apache_production_update_ni.sh [--ssl] [--dry-run]
 
 ### Notes
 
-* **Backups**: All scripts back up .env.prod and frontend files to /tmp/docman_env_backup/.
+* **Backups**: The deploy and update scripts back up the existing backend env and export discovered `.env*` files into `~/docman/env-backups/`. The non-interactive update script also keeps a working copy under `/tmp/docman_env_backup/` for auto-rollback.
 * **Rollback**: Scripts automatically restore previous state if a command fails.
 * **Root Privileges**: Scripts must be run as root or via sudo.
 * **Dry-Run Logs**: Non-interactive script logs simulated commands for review without applying changes.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 __by Resonance Designs__
 
-![Static Badge](https://img.shields.io/badge/Version-2.2.4-orange)
-![Static Badge](https://img.shields.io/badge/Latest_Release-v2.2.4-green)
+![Static Badge](https://img.shields.io/badge/Version-2.2.5-orange)
+![Static Badge](https://img.shields.io/badge/Latest_Release-v2.2.5-green)
 
 A modern, full-stack document management system built with Node.js, MongoDB, and a frontend currently migrating from React to Vue/Vuetify. DocMan provides secure document storage, collaborative workflows, and comprehensive review management.
 

--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -43,6 +43,7 @@ AUTHENTIK_ISSUER=<AUTHENTIK_ISSUER> # Example: https://accounts.resonancedesigns
 AUTHENTIK_AUDIENCE=<AUTHENTIK_AUDIENCE> # Usually the Authentik client ID / audience expected by DocMan
 AUTHENTIK_CLIENT_ID=<AUTHENTIK_CLIENT_ID> # Optional alias to keep client naming explicit
 AUTHENTIK_BASE_URL=<AUTHENTIK_BASE_URL> # Optional alias for issuer base if you standardize config this way
+AUTHENTIK_JWKS_URL=<AUTHENTIK_JWKS_URL> # Preferred JWKS endpoint for verifying Authentik RS256 access tokens, e.g. https://accounts.resonancedesigns.dev/application/o/rdocman-web/jwks/
 AUTHENTIK_JWT_PUBLIC_KEY=<AUTHENTIK_JWT_PUBLIC_KEY> # PEM-encoded public key for verifying Authentik RS256 access tokens; escape newlines as \\n in env files if needed
 
 # AWS SES Configuration for Email Notifications

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rd-docman-backend",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rd-docman-backend",
-      "version": "2.2.4",
+      "version": "2.2.5",
       "license": "UNLICENSED",
       "dependencies": {
         "@aws-sdk/client-ses": "^3.864.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rdocman-backend",
   "private": true,
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "RDocMan is a document management application for all sorts of documents. Track updates, schedule reviews, categorize, and upload versions of your docs. DocMan hopes to be the most comprehensive piece of software to manage all of your documentation. You can schedule your documentation for review between stakeholders, the original authors, contributors, relevant tech leads, etc... Categorize, analyze, version repositories, and basically everything you would need to keep your documentation well organized, maintained, analyzed, and backed up.",
   "keywords": [
     "Document Management",

--- a/backend/src/__tests__/analytics.test.js
+++ b/backend/src/__tests__/analytics.test.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import request from "supertest";

--- a/backend/src/__tests__/auth.integration.test.js
+++ b/backend/src/__tests__/auth.integration.test.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import request from "supertest";

--- a/backend/src/__tests__/auth.test.js
+++ b/backend/src/__tests__/auth.test.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import request from "supertest";

--- a/backend/src/__tests__/categories.test.js
+++ b/backend/src/__tests__/categories.test.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import request from "supertest";

--- a/backend/src/__tests__/docs.test.js
+++ b/backend/src/__tests__/docs.test.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import request from "supertest";

--- a/backend/src/__tests__/externalContacts.test.js
+++ b/backend/src/__tests__/externalContacts.test.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import request from "supertest";

--- a/backend/src/__tests__/middleware/cacheMiddleware.test.js
+++ b/backend/src/__tests__/middleware/cacheMiddleware.test.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/__tests__/middleware/cacheMiddleware.test.js
  * @description Unit tests for caching middleware
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { jest } from '@jest/globals';

--- a/backend/src/__tests__/middleware/performanceMonitor.test.js
+++ b/backend/src/__tests__/middleware/performanceMonitor.test.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/__tests__/middleware/performanceMonitor.test.js
  * @description Unit tests for performance monitoring middleware
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { jest } from '@jest/globals';

--- a/backend/src/__tests__/notifications.test.js
+++ b/backend/src/__tests__/notifications.test.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import request from "supertest";

--- a/backend/src/__tests__/projects.test.js
+++ b/backend/src/__tests__/projects.test.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import request from "supertest";

--- a/backend/src/__tests__/services/documentService.test.js
+++ b/backend/src/__tests__/services/documentService.test.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/__tests__/services/documentService.test.js
  * @description Unit tests for document service business logic
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { jest } from '@jest/globals';

--- a/backend/src/__tests__/services/queryOptimizationService.test.js
+++ b/backend/src/__tests__/services/queryOptimizationService.test.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/__tests__/services/queryOptimizationService.test.js
  * @description Unit tests for query optimization service
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { jest } from '@jest/globals';

--- a/backend/src/__tests__/setup.js
+++ b/backend/src/__tests__/setup.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/__tests__/setup.js
  * @description Global test setup and configuration
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { jest } from '@jest/globals';

--- a/backend/src/__tests__/teams.test.js
+++ b/backend/src/__tests__/teams.test.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import request from "supertest";

--- a/backend/src/__tests__/users.test.js
+++ b/backend/src/__tests__/users.test.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import request from "supertest";

--- a/backend/src/config/database-indexes.js
+++ b/backend/src/config/database-indexes.js
@@ -4,7 +4,7 @@
  * @module database-indexes
  * @description Database index definitions for optimal query performance
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/config/db.js
+++ b/backend/src/config/db.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/config/swagger.js
+++ b/backend/src/config/swagger.js
@@ -22,21 +22,21 @@ const options = {
             description: 'Comprehensive Document Management System API',
             contact: {
                 name: 'Richard Bakos',
-                email: 'support@docman.com'
+                email: 'info@resonancedesigns.dev'
             },
             license: {
                 name: 'UNLICENSED',
-                url: 'https://docman.com/license'
+                url: 'https://resonancedesigns.dev'
             }
         },
         servers: [
             {
-                url: process.env.API_URL || 'http://localhost:5001/api',
-                description: 'Development server'
+                url: process.env.API_URL || 'https://api.docman.resonancedesigns.dev/api',
+                description: 'Production server'
             },
             {
-                url: 'https://api.docman.com/api',
-                description: 'Production server'
+                url: 'http://localhost:5001/api',
+                description: 'Local development server'
             }
         ],
         components: {

--- a/backend/src/config/swagger.js
+++ b/backend/src/config/swagger.js
@@ -4,7 +4,7 @@
  * @module swagger
  * @description OpenAPI/Swagger configuration for comprehensive API documentation
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import swaggerJsdoc from 'swagger-jsdoc';

--- a/backend/src/config/upstash.js
+++ b/backend/src/config/upstash.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import {Ratelimit} from "@upstash/ratelimit";

--- a/backend/src/controllers/analyticsController.js
+++ b/backend/src/controllers/analyticsController.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import Doc from "../models/Doc.js";

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -4,7 +4,7 @@
  * @controller authController
  * @description Authentication controller handling user registration, login, logout, and password reset functionality
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import crypto from "crypto";

--- a/backend/src/controllers/booksController.js
+++ b/backend/src/controllers/booksController.js
@@ -4,7 +4,7 @@
  * @controller booksController
  * @description Book management controller for organizing documents into collections
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import Book from "../models/Book.js";

--- a/backend/src/controllers/categoriesController.js
+++ b/backend/src/controllers/categoriesController.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import Category from "../models/Category.js";

--- a/backend/src/controllers/customChartsController.js
+++ b/backend/src/controllers/customChartsController.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import CustomChart from "../models/CustomChart.js";

--- a/backend/src/controllers/docsController.js
+++ b/backend/src/controllers/docsController.js
@@ -4,7 +4,7 @@
  * @controller docsController
  * @description Document management controller for CRUD operations, file uploads, version control, and review workflows
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import Doc from "../models/Doc.js";

--- a/backend/src/controllers/externalContactsController.js
+++ b/backend/src/controllers/externalContactsController.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import ExternalContact from "../models/ExternalContact.js";

--- a/backend/src/controllers/notificationsController.js
+++ b/backend/src/controllers/notificationsController.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import Notification from "../models/Notification.js";

--- a/backend/src/controllers/profilePictureController.js
+++ b/backend/src/controllers/profilePictureController.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import User from "../models/User.js";

--- a/backend/src/controllers/projectsController.js
+++ b/backend/src/controllers/projectsController.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import Project from "../models/Project.js";

--- a/backend/src/controllers/reviewController.js
+++ b/backend/src/controllers/reviewController.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import ReviewAssignment from "../models/ReviewAssignment.js";

--- a/backend/src/controllers/systemController.js
+++ b/backend/src/controllers/systemController.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import os from 'os';

--- a/backend/src/controllers/teamsController.js
+++ b/backend/src/controllers/teamsController.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import Team from "../models/Team.js";

--- a/backend/src/controllers/uploadFileController.js
+++ b/backend/src/controllers/uploadFileController.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import File from "../models/File.js";  // Your file schema/model

--- a/backend/src/controllers/usersController.js
+++ b/backend/src/controllers/usersController.js
@@ -4,7 +4,7 @@
  * @controller usersController
  * @description User management controller for CRUD operations, profile updates, and user administration
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import bcrypt from "bcrypt";

--- a/backend/src/lib/emailService.js
+++ b/backend/src/lib/emailService.js
@@ -27,7 +27,7 @@ const sesClient = new SESClient({
 // Function to send email using AWS SES
 export async function sendEmail(to, subject, text, html) {
     // Use environment-specific sender email
-    const senderEmail = process.env.AWS_SES_SENDER_EMAIL || "noreply@resonancedesigns.dev";
+    const senderEmail = process.env.AWS_SES_SENDER_EMAIL || "info@resonancedesigns.dev";
     
     const params = {
         Destination: {

--- a/backend/src/lib/emailService.js
+++ b/backend/src/lib/emailService.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { SESClient, SendEmailCommand } from "@aws-sdk/client-ses";

--- a/backend/src/lib/errorHandler.js
+++ b/backend/src/lib/errorHandler.js
@@ -4,7 +4,7 @@
  * @module errorHandler
  * @description Standardized error handling and logging utilities for consistent error management
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import fs from 'fs';

--- a/backend/src/lib/globalUtils.js
+++ b/backend/src/lib/globalUtils.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 // backend/src/lib/globalUtils.js

--- a/backend/src/lib/jwtSecret.js
+++ b/backend/src/lib/jwtSecret.js
@@ -4,7 +4,7 @@
  * @module jwtSecret
  * @description Shared JWT secret configuration for token signing and verification
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import dotenv from "dotenv";

--- a/backend/src/lib/secretToken.js
+++ b/backend/src/lib/secretToken.js
@@ -4,7 +4,7 @@
  * @module secretToken
  * @description JWT token utilities for creating, verifying, and blacklisting authentication tokens
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import jwt from "jsonwebtoken";

--- a/backend/src/lib/sharedValidation.js
+++ b/backend/src/lib/sharedValidation.js
@@ -4,7 +4,7 @@
  * @module sharedValidation
  * @description Shared validation utilities for consistent validation across all services
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import validator from 'validator';

--- a/backend/src/lib/utils.js
+++ b/backend/src/lib/utils.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 /**

--- a/backend/src/lib/validation.js
+++ b/backend/src/lib/validation.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 // Server-side validation utilities

--- a/backend/src/middleware/authMid.js
+++ b/backend/src/middleware/authMid.js
@@ -4,7 +4,7 @@
  * @middleware authMid
  * @description JWT authentication middleware for verifying Bearer tokens and protecting routes
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import jwt from "jsonwebtoken";

--- a/backend/src/middleware/authRateLimiter.js
+++ b/backend/src/middleware/authRateLimiter.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { Ratelimit } from "@upstash/ratelimit";

--- a/backend/src/middleware/cacheMiddleware.js
+++ b/backend/src/middleware/cacheMiddleware.js
@@ -4,7 +4,7 @@
  * @middleware cacheMiddleware
  * @description Caching middleware for API responses to improve performance
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 

--- a/backend/src/middleware/inputValidation.js
+++ b/backend/src/middleware/inputValidation.js
@@ -4,7 +4,7 @@
  * @middleware inputValidation
  * @description Centralized input validation middleware for sanitizing and validating all user inputs
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import validator from 'validator';

--- a/backend/src/middleware/performanceMonitor.js
+++ b/backend/src/middleware/performanceMonitor.js
@@ -4,7 +4,7 @@
  * @middleware performanceMonitor
  * @description Performance monitoring middleware for tracking API response times and database query performance
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 

--- a/backend/src/middleware/rateLimiter.js
+++ b/backend/src/middleware/rateLimiter.js
@@ -4,7 +4,7 @@
  * @middleware rateLimiter
  * @description Rate limiting middleware using Redis for preventing API abuse and ensuring fair usage
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import ratelimit from "../config/upstash.js";

--- a/backend/src/middleware/requireRole.js
+++ b/backend/src/middleware/requireRole.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 // middleware/requireRole.js

--- a/backend/src/middleware/securityHeaders.js
+++ b/backend/src/middleware/securityHeaders.js
@@ -4,7 +4,7 @@
  * @middleware securityHeaders
  * @description Comprehensive security headers middleware for protecting against common web vulnerabilities
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 

--- a/backend/src/middleware/uploadMid.js
+++ b/backend/src/middleware/uploadMid.js
@@ -4,7 +4,7 @@
  * @middleware uploadMid
  * @description File upload middleware for handling multipart form data and file validation
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import multer from "multer";

--- a/backend/src/models/BlacklistedToken.js
+++ b/backend/src/models/BlacklistedToken.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from "mongoose";

--- a/backend/src/models/Book.js
+++ b/backend/src/models/Book.js
@@ -4,7 +4,7 @@
  * @model Book
  * @description Book model schema for organizing documents into collections within teams and projects
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from "mongoose";

--- a/backend/src/models/Category.js
+++ b/backend/src/models/Category.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 // backend/src/models/Category.js

--- a/backend/src/models/CustomChart.js
+++ b/backend/src/models/CustomChart.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from "mongoose";

--- a/backend/src/models/Doc.js
+++ b/backend/src/models/Doc.js
@@ -4,7 +4,7 @@
  * @model Doc
  * @description Document model schema for managing document metadata, version history, stakeholders, and review workflows
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 // backend/src/models/Doc.js

--- a/backend/src/models/ExternalContact.js
+++ b/backend/src/models/ExternalContact.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from "mongoose";

--- a/backend/src/models/ExternalContactType.js
+++ b/backend/src/models/ExternalContactType.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from "mongoose";

--- a/backend/src/models/File.js
+++ b/backend/src/models/File.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from "mongoose";

--- a/backend/src/models/Notification.js
+++ b/backend/src/models/Notification.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 // backend/src/models/Notification.js

--- a/backend/src/models/Project.js
+++ b/backend/src/models/Project.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 // backend/src/models/Project.js

--- a/backend/src/models/ReviewAssignment.js
+++ b/backend/src/models/ReviewAssignment.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from "mongoose";

--- a/backend/src/models/Team.js
+++ b/backend/src/models/Team.js
@@ -4,7 +4,7 @@
  * @model Team
  * @description Team model schema for collaborative team management with members, invitations, and project associations
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 // backend/src/models/Team.js

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -4,7 +4,7 @@
  * @model User
  * @description User model schema for authentication, profile management, and role-based access control
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from "mongoose";

--- a/backend/src/routes/analyticsRoutes.js
+++ b/backend/src/routes/analyticsRoutes.js
@@ -4,7 +4,7 @@
  * @routes analyticsRoutes
  * @description Analytics routes for generating reports, metrics, and data visualizations
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/authRoutes.js
+++ b/backend/src/routes/authRoutes.js
@@ -4,7 +4,7 @@
  * @routes authRoutes
  * @description Authentication routes for user registration, login, logout, password reset, and token refresh
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/booksRoutes.js
+++ b/backend/src/routes/booksRoutes.js
@@ -4,7 +4,7 @@
  * @routes booksRoutes
  * @description Book management routes for organizing documents into collections
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/categoriesRoutes.js
+++ b/backend/src/routes/categoriesRoutes.js
@@ -4,7 +4,7 @@
  * @routes categoriesRoutes
  * @description Category management routes for organizing and managing document categories
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/customChartsRoutes.js
+++ b/backend/src/routes/customChartsRoutes.js
@@ -4,7 +4,7 @@
  * @routes customChartsRoutes
  * @description Custom chart routes for creating and managing personalized analytics
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/docsRoutes.js
+++ b/backend/src/routes/docsRoutes.js
@@ -4,7 +4,7 @@
  * @routes docsRoutes
  * @description Document management routes for CRUD operations, file uploads, version control, and review workflows
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/externalContactsRoutes.js
+++ b/backend/src/routes/externalContactsRoutes.js
@@ -4,7 +4,7 @@
  * @routes externalContactsRoutes
  * @description External contact management routes for stakeholder organization
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/notificationsRoutes.js
+++ b/backend/src/routes/notificationsRoutes.js
@@ -4,7 +4,7 @@
  * @routes notificationsRoutes
  * @description Notification routes for managing user notifications and alerts
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/projectsRoutes.js
+++ b/backend/src/routes/projectsRoutes.js
@@ -4,7 +4,7 @@
  * @routes projectsRoutes
  * @description Project management routes for project operations and team assignments
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/reviewRoutes.js
+++ b/backend/src/routes/reviewRoutes.js
@@ -4,7 +4,7 @@
  * @routes reviewRoutes
  * @description Document review routes for managing review workflows and approvals
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/systemRoutes.js
+++ b/backend/src/routes/systemRoutes.js
@@ -4,7 +4,7 @@
  * @routes systemRoutes
  * @description System information routes for health checks, status monitoring, and diagnostics
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/teamsRoutes.js
+++ b/backend/src/routes/teamsRoutes.js
@@ -4,7 +4,7 @@
  * @routes teamsRoutes
  * @description Team management routes for team operations, member management, and collaboration
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/uploadRoutes.js
+++ b/backend/src/routes/uploadRoutes.js
@@ -4,7 +4,7 @@
  * @routes uploadRoutes
  * @description File upload routes for handling document uploads and file management
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/usersRoutes.js
+++ b/backend/src/routes/usersRoutes.js
@@ -4,7 +4,7 @@
  * @routes usersRoutes
  * @description User management routes for CRUD operations, profile updates, and administrative functions
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/scripts/clearData/clearAllCollections.js
+++ b/backend/src/scripts/clearData/clearAllCollections.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearAllCollections.js
  * @description Script to clear all collections from the database
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearBlacklistedTokens.js
+++ b/backend/src/scripts/clearData/clearBlacklistedTokens.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearBlacklistedTokens.js
  * @description Script to clear all blacklisted tokens from the database
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearBooks.js
+++ b/backend/src/scripts/clearData/clearBooks.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearBooks.js
  * @description Script to clear all books from the database
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearCategories.js
+++ b/backend/src/scripts/clearData/clearCategories.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearCategories.js
  * @description Script to clear all categories from the database
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearCustomCharts.js
+++ b/backend/src/scripts/clearData/clearCustomCharts.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearCustomCharts.js
  * @description Script to clear all custom charts from the database
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearDocs.js
+++ b/backend/src/scripts/clearData/clearDocs.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearDocs.js
  * @description Script to clear all documents from the database
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearExternalContactTypes.js
+++ b/backend/src/scripts/clearData/clearExternalContactTypes.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearExternalContactTypes.js
  * @description Script to clear all external contact types from the database
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearExternalContacts.js
+++ b/backend/src/scripts/clearData/clearExternalContacts.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearExternalContacts.js
  * @description Script to clear all external contacts from the database
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearFiles.js
+++ b/backend/src/scripts/clearData/clearFiles.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearFiles.js
  * @description Script to clear all files from the database
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearNotifications.js
+++ b/backend/src/scripts/clearData/clearNotifications.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearNotifications.js
  * @description Script to clear all notifications from the database
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearProjects.js
+++ b/backend/src/scripts/clearData/clearProjects.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearProjects.js
  * @description Script to clear all projects from the database
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearReviewAssignments.js
+++ b/backend/src/scripts/clearData/clearReviewAssignments.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearReviewAssignments.js
  * @description Script to clear all review assignments from the database
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearTeams.js
+++ b/backend/src/scripts/clearData/clearTeams.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearTeams.js
  * @description Script to clear all teams from the database
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearUsers.js
+++ b/backend/src/scripts/clearData/clearUsers.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearUsers.js
  * @description Script to clear all users from the database
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/createBookCategory.js
+++ b/backend/src/scripts/createBookCategory.js
@@ -4,7 +4,7 @@
  * @script createBookCategory
  * @description Script to create a sample Book category for testing
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 

--- a/backend/src/scripts/dummyData/createAllDummyData.js
+++ b/backend/src/scripts/dummyData/createAllDummyData.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createAllDummyData.js
  * @description Script to create dummy data for all collections in the database
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyBlacklistedTokens.js
+++ b/backend/src/scripts/dummyData/createDummyBlacklistedTokens.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyBlacklistedTokens.js
  * @description Script to create dummy blacklisted tokens in the database
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyBooks.js
+++ b/backend/src/scripts/dummyData/createDummyBooks.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyBooks.js
  * @description Script to create dummy books in the database
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyCategories.js
+++ b/backend/src/scripts/dummyData/createDummyCategories.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyCategories.js
  * @description Script to create dummy categories in the database
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyCustomCharts.js
+++ b/backend/src/scripts/dummyData/createDummyCustomCharts.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyCustomCharts.js
  * @description Script to create dummy custom charts in the database
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyDocs.js
+++ b/backend/src/scripts/dummyData/createDummyDocs.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyDocs.js
  * @description Script to create dummy documents in the database
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyExternalContactTypes.js
+++ b/backend/src/scripts/dummyData/createDummyExternalContactTypes.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyExternalContactTypes.js
  * @description Script to create dummy external contact types in the database
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyExternalContacts.js
+++ b/backend/src/scripts/dummyData/createDummyExternalContacts.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyExternalContacts.js
  * @description Script to create dummy external contacts in the database
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyFiles.js
+++ b/backend/src/scripts/dummyData/createDummyFiles.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyFiles.js
  * @description Script to create dummy file records in the database
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyNotifications.js
+++ b/backend/src/scripts/dummyData/createDummyNotifications.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyNotifications.js
  * @description Script to create dummy notifications in the database
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyProjects.js
+++ b/backend/src/scripts/dummyData/createDummyProjects.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyProjects.js
  * @description Script to create dummy projects in the database
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyReviewAssignments.js
+++ b/backend/src/scripts/dummyData/createDummyReviewAssignments.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyReviewAssignments.js
  * @description Script to create dummy review assignments in the database
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyTeams.js
+++ b/backend/src/scripts/dummyData/createDummyTeams.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyTeams.js
  * @description Script to create dummy teams in the database
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyUsers.js
+++ b/backend/src/scripts/dummyData/createDummyUsers.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyUsers.js
  * @description Script to create dummy users in the database
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/linkAuthentikUsers.js
+++ b/backend/src/scripts/linkAuthentikUsers.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/linkAuthentikUsers.js
  * @description Bulk link existing DocMan users to Authentik subject IDs through an explicit mapping file
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import fs from "fs";

--- a/backend/src/scripts/migrateCategoryTypes.js
+++ b/backend/src/scripts/migrateCategoryTypes.js
@@ -4,7 +4,7 @@
  * @script migrateCategoryTypes
  * @description Migration script to add type field to existing categories
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 

--- a/backend/src/scripts/migrateReviewFields.js
+++ b/backend/src/scripts/migrateReviewFields.js
@@ -4,7 +4,7 @@
  * @script migrateReviewFields
  * @description Migration script to update documents from old reviewDate field to new review system
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from "mongoose";

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/server.js
  * @description Main entry point of the DocMan backend application
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { connectDB } from "./config/db.js";

--- a/backend/src/services/documentService.js
+++ b/backend/src/services/documentService.js
@@ -4,7 +4,7 @@
  * @service documentService
  * @description Business logic service for document operations including CRUD, validation, and access control
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from "mongoose";

--- a/backend/src/services/identityService.js
+++ b/backend/src/services/identityService.js
@@ -8,6 +8,7 @@
  * @license UNLICENSED
  */
 import jwt from "jsonwebtoken";
+import { createPublicKey } from "node:crypto";
 import User from "../models/User.js";
 import BlacklistedToken from "../models/BlacklistedToken.js";
 import { TOKEN_KEY } from "../lib/jwtSecret.js";
@@ -16,6 +17,13 @@ const USER_SELECT_FIELDS = "-password -refreshTokenHash -resetPasswordToken -res
 const AUTHENTIK_ISSUER = process.env.AUTHENTIK_ISSUER || process.env.AUTHENTIK_BASE_URL || "";
 const AUTHENTIK_AUDIENCE = process.env.AUTHENTIK_AUDIENCE || process.env.AUTHENTIK_CLIENT_ID || "";
 const AUTHENTIK_JWT_PUBLIC_KEY = normalizePem(process.env.AUTHENTIK_JWT_PUBLIC_KEY || "");
+const AUTHENTIK_JWKS_URL = resolveAuthentikJwksUrl();
+const AUTHENTIK_JWKS_CACHE_TTL_MS = 5 * 60 * 1000;
+
+let authentikJwksCache = {
+    fetchedAt: 0,
+    keysByKid: new Map(),
+};
 
 function createAuthError(message, statusCode = 401) {
     const error = new Error(message);
@@ -27,8 +35,30 @@ function normalizePem(value) {
     return value ? value.replace(/\\n/g, "\n").trim() : "";
 }
 
+function normalizeIssuer(value) {
+    if (!value) {
+        return "";
+    }
+
+    return value.endsWith("/") ? value : `${value}/`;
+}
+
+function resolveAuthentikJwksUrl() {
+    const explicitJwksUrl = process.env.AUTHENTIK_JWKS_URL || "";
+    if (explicitJwksUrl) {
+        return explicitJwksUrl.trim();
+    }
+
+    const issuer = normalizeIssuer(AUTHENTIK_ISSUER);
+    if (!issuer) {
+        return "";
+    }
+
+    return `${issuer}jwks/`;
+}
+
 function isAuthentikConfigured() {
-    return Boolean(AUTHENTIK_ISSUER && AUTHENTIK_AUDIENCE && AUTHENTIK_JWT_PUBLIC_KEY);
+    return Boolean(AUTHENTIK_ISSUER && AUTHENTIK_AUDIENCE && (AUTHENTIK_JWT_PUBLIC_KEY || AUTHENTIK_JWKS_URL));
 }
 
 function isAuthentikToken(decoded) {
@@ -127,7 +157,8 @@ export async function resolveAuthentikTokenIdentity(token) {
         throw createAuthError("Authentik identity is not configured", 500);
     }
 
-    const decoded = jwt.verify(token, AUTHENTIK_JWT_PUBLIC_KEY, {
+    const verificationKey = await resolveAuthentikVerificationKey(token);
+    const decoded = jwt.verify(token, verificationKey, {
         algorithms: ["RS256"],
         issuer: AUTHENTIK_ISSUER,
         audience: AUTHENTIK_AUDIENCE,
@@ -148,6 +179,52 @@ export async function resolveAuthentikTokenIdentity(token) {
         tokenClaims: decoded,
         user,
     };
+}
+
+async function resolveAuthentikVerificationKey(token) {
+    if (AUTHENTIK_JWT_PUBLIC_KEY) {
+        return AUTHENTIK_JWT_PUBLIC_KEY;
+    }
+
+    if (!AUTHENTIK_JWKS_URL) {
+        throw createAuthError("Authentik JWKS URL is not configured", 500);
+    }
+
+    const decodedToken = jwt.decode(token, { complete: true });
+    const kid = decodedToken?.header?.kid;
+    if (!kid) {
+        throw createAuthError("Authentik token is missing a key id");
+    }
+
+    const jwk = await getAuthentikJwk(kid);
+    if (!jwk) {
+        throw createAuthError(`Authentik signing key ${kid} was not found`, 401);
+    }
+
+    return createPublicKey({ key: jwk, format: "jwk" });
+}
+
+async function getAuthentikJwk(kid) {
+    const now = Date.now();
+    if (authentikJwksCache.keysByKid.size && (now - authentikJwksCache.fetchedAt) < AUTHENTIK_JWKS_CACHE_TTL_MS) {
+        return authentikJwksCache.keysByKid.get(kid) || null;
+    }
+
+    const response = await fetch(AUTHENTIK_JWKS_URL);
+    if (!response.ok) {
+        throw createAuthError(`Unable to fetch Authentik JWKS (${response.status})`, 500);
+    }
+
+    const payload = await response.json();
+    const keys = Array.isArray(payload?.keys) ? payload.keys : [];
+    const keysByKid = new Map(keys.filter((key) => key?.kid).map((key) => [key.kid, key]));
+
+    authentikJwksCache = {
+        fetchedAt: now,
+        keysByKid,
+    };
+
+    return keysByKid.get(kid) || null;
 }
 
 /**

--- a/backend/src/services/identityService.js
+++ b/backend/src/services/identityService.js
@@ -4,7 +4,7 @@
  * @service identityService
  * @description Transitional identity resolution service for local JWT auth today and shared suite identity providers later
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import jwt from "jsonwebtoken";

--- a/backend/src/services/queryOptimizationService.js
+++ b/backend/src/services/queryOptimizationService.js
@@ -4,7 +4,7 @@
  * @service queryOptimizationService
  * @description Optimized database queries with caching and performance monitoring
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/services/userService.js
+++ b/backend/src/services/userService.js
@@ -4,7 +4,7 @@
  * @service userService
  * @description Business logic service for user operations including CRUD, validation, and access control
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import User from "../models/User.js";

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docman-docs-site",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docman-docs-site",
-      "version": "2.2.4",
+      "version": "2.2.5",
       "dependencies": {
         "@docusaurus/core": "3.9.1",
         "@docusaurus/preset-classic": "3.9.1",

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docman-docs-site",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "private": true,
   "description": "Docusaurus documentation site for DocMan.",
   "scripts": {

--- a/docs/DEVELOPER_ONBOARDING.md
+++ b/docs/DEVELOPER_ONBOARDING.md
@@ -237,7 +237,7 @@ Every file should have a descriptive header:
  * @service documentService
  * @description Business logic for document management operations
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 ```

--- a/docs/RELEASE_AND_DEPLOYMENT.md
+++ b/docs/RELEASE_AND_DEPLOYMENT.md
@@ -275,6 +275,24 @@ For static frontend-only updates, copy the selected `dist` output into the Apach
 
 For backend updates, update the backend application path, preserve `.env.prod`, install production dependencies, and restart the backend service.
 
+For full recovery deploys using `scripts/apache_production_deploy.sh`:
+
+- back up the existing `/var/www/docman` tree instead of deleting it blindly
+- preserve previous `.env*` files during that backup
+- export those env files into `~/docman/env-backups/`
+- preserve the last backend env file as `~/docman/previous-backend.env.prod`
+- prefer that preserved backend env file as the prompt-default source on the next recovery run
+
+This env preservation behavior exists specifically because production recovery often needs to re-enter:
+
+- MongoDB connection values
+- `NODE_PORT`
+- Upstash Redis credentials
+- AWS SES credentials
+- JWT/auth token secrets
+
+Maintainers should treat `~/docman/previous-backend.env.prod` as a recovery aid, not as a replacement for proper secret management. After a successful recovery deploy, confirm the resulting `/var/www/docman/backend/.env.prod` matches the intended live configuration.
+
 ## Data Safety Rules
 
 Production deploys must not clear or recreate collections.

--- a/frontend-vue/package-lock.json
+++ b/frontend-vue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rd-docman-frontend-vue",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rd-docman-frontend-vue",
-      "version": "2.2.4",
+      "version": "2.2.5",
       "dependencies": {
         "@mdi/font": "^7.4.47",
         "axios": "^1.11.0",

--- a/frontend-vue/package.json
+++ b/frontend-vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rd-docman-frontend-vue",
   "private": true,
-  "version": "2.2.4",
+  "version": "2.2.5",
   "type": "module",
   "description": "Vue and Vuetify migration foundation for DocMan.",
   "scripts": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rd-docman-frontend",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rd-docman-frontend",
-      "version": "2.2.4",
+      "version": "2.2.5",
       "license": "UNLICENSED",
       "dependencies": {
         "@hookform/resolvers": "^3.3.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rd-docman-frontend",
   "private": true,
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "DocMan is a document management application for all sorts of documents. Track updates, schedule reviews, categorize, and upload versions of your docs. DocMan hopes to be the most comprehensive piece of software to manage all of your documentation. You can schedule your documentation for review between stakeholders, the original authors, contributors, relevant tech leads, etc... Categorize, analyze, version repositories, and basically everything you would need to keep your documentation well organized, maintained, analyzed, and backed up.",
   "keywords": [
     "Document Management",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/App.jsx
  * @description Main application component that handles routing and authentication state
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { Route, Routes } from "react-router";

--- a/frontend/src/README.md
+++ b/frontend/src/README.md
@@ -11,7 +11,7 @@ All frontend files should include a comment header with the following format:
  * @page [ComponentName]
  * @description [Brief description of the component/page]
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 ```

--- a/frontend/src/__tests__/hooks/useFormData.test.js
+++ b/frontend/src/__tests__/hooks/useFormData.test.js
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/__tests__/hooks/useFormData.test.js
  * @description Unit tests for useFormData custom hook
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { renderHook, waitFor } from '@testing-library/react';

--- a/frontend/src/__tests__/setup.js
+++ b/frontend/src/__tests__/setup.js
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/__tests__/setup.js
  * @description Global test setup and configuration for React components
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { expect, afterEach, vi } from 'vitest';

--- a/frontend/src/components/AccountNav.jsx
+++ b/frontend/src/components/AccountNav.jsx
@@ -4,7 +4,7 @@
  * @component AccountNav
  * @description Account navigation dropdown component with profile, teams, and projects links
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/BookTable.jsx
+++ b/frontend/src/components/BookTable.jsx
@@ -4,7 +4,7 @@
  * @component BookTable
  * @description Component for displaying a book in a table row with actions.
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/CatTable.jsx
+++ b/frontend/src/components/CatTable.jsx
@@ -4,7 +4,7 @@
  * @component CatTable
  * @description Category table component for displaying and managing document categories
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/DocCard.jsx
+++ b/frontend/src/components/DocCard.jsx
@@ -4,7 +4,7 @@
  * @component DocCard
  * @description Component for displaying a document card with title, author, description, and review date.
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/DocTable.jsx
+++ b/frontend/src/components/DocTable.jsx
@@ -4,7 +4,7 @@
  * @component DocTable
  * @description Component for displaying a document in a table row with actions.
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/DocsNotFound.jsx
+++ b/frontend/src/components/DocsNotFound.jsx
@@ -4,7 +4,7 @@
  * @component DocNotFound
  * @description Empty state component displayed when no documents are found with call-to-action
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { NotebookIcon } from "lucide-react";

--- a/frontend/src/components/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary.jsx
@@ -4,7 +4,7 @@
  * @component ErrorBoundary
  * @description Component for catching and displaying React errors
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import React from "react";

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -4,7 +4,7 @@
  * @component Footer
  * @description Application footer component with copyright information and company branding
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 /**

--- a/frontend/src/components/InlineLoader.jsx
+++ b/frontend/src/components/InlineLoader.jsx
@@ -4,7 +4,7 @@
  * @component InlineLoader
  * @description Component for loading indicators in the UI.
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import React from 'react';

--- a/frontend/src/components/LoadingSpinner.jsx
+++ b/frontend/src/components/LoadingSpinner.jsx
@@ -4,7 +4,7 @@
  * @component LoadingSpinner
  * @description Component for displaying a loading spinner with an optional message. The component can be customized in terms of size, color and whether it should cover the entire screen or not.
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import React from 'react';

--- a/frontend/src/components/NavAdmin.jsx
+++ b/frontend/src/components/NavAdmin.jsx
@@ -4,7 +4,7 @@
  * @component NavAdmin
  * @description Component for displaying navigation links for the admin panel.
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { Link } from "react-router";

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -4,7 +4,7 @@
  * @component Navbar
  * @description Component for the main navigation bar with responsive menu and authentication handling.
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/NotificationBell.jsx
+++ b/frontend/src/components/NotificationBell.jsx
@@ -4,7 +4,7 @@
  * @component NotificationBell
  * @description Notification bell component with dropdown for displaying user notifications
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/PaginatedBookTable.jsx
+++ b/frontend/src/components/PaginatedBookTable.jsx
@@ -4,7 +4,7 @@
  * @component PaginatedBookTable
  * @description Paginated table component for displaying books with sorting, filtering, and bulk actions
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/PaginatedCatTable.jsx
+++ b/frontend/src/components/PaginatedCatTable.jsx
@@ -4,7 +4,7 @@
  * @component PaginatedCatTable
  * @description Component for displaying categories in a paginated table.
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/PaginatedDocTable.jsx
+++ b/frontend/src/components/PaginatedDocTable.jsx
@@ -4,7 +4,7 @@
  * @component PaginatedDocTable
  * @description Paginated table component for displaying documents with sorting, filtering, and bulk actions
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/PaginatedFileVersionTable.jsx
+++ b/frontend/src/components/PaginatedFileVersionTable.jsx
@@ -4,7 +4,7 @@
  * @component PaginatedFileVersionTable
  * @description Paginated and sortable table for document file version history (sortable by Version and Uploaded)
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/PaginatedUserTable.jsx
+++ b/frontend/src/components/PaginatedUserTable.jsx
@@ -4,7 +4,7 @@
  * @component PaginatedUserTable
  * @description Paginated table component for displaying users with administrative controls and filtering
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/ProtectedRoutes.jsx
+++ b/frontend/src/components/ProtectedRoutes.jsx
@@ -4,7 +4,7 @@
  * @component ProtectedRoutes
  * @description Route protection component for handling authentication and authorization
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { Navigate } from "react-router";

--- a/frontend/src/components/RateLimitedUI.jsx
+++ b/frontend/src/components/RateLimitedUI.jsx
@@ -4,7 +4,7 @@
  * @component RateLimitedUI
  * @description Rate limit notification component displayed when API request limits are exceeded
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { ZapIcon } from "lucide-react";

--- a/frontend/src/components/ReviewCompletionToggle.jsx
+++ b/frontend/src/components/ReviewCompletionToggle.jsx
@@ -4,7 +4,7 @@
  * @component ReviewCompletionToggle
  * @description Toggle component for review assignees to mark their review as complete
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState } from "react";

--- a/frontend/src/components/ReviewStatusSummary.jsx
+++ b/frontend/src/components/ReviewStatusSummary.jsx
@@ -4,7 +4,7 @@
  * @component ReviewStatusSummary
  * @description Summary component showing overall review completion status
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { CheckCircleIcon, ClockIcon, UsersIcon } from "lucide-react";

--- a/frontend/src/components/UserTable.jsx
+++ b/frontend/src/components/UserTable.jsx
@@ -4,7 +4,7 @@
  * @component UserTable
  * @description Component for displaying a user in a table row with actions.
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/filters/DateRangeFilter.jsx
+++ b/frontend/src/components/filters/DateRangeFilter.jsx
@@ -4,7 +4,7 @@
  * @component DateRangeFilter
  * @description Date range filter component with calendar picker for filtering by date periods
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { CalendarIcon, XIcon } from "lucide-react";

--- a/frontend/src/components/filters/DropdownFilter.jsx
+++ b/frontend/src/components/filters/DropdownFilter.jsx
@@ -4,7 +4,7 @@
  * @component DropdownFilter
  * @description Dropdown filter component with search functionality for selecting filter options
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { ChevronDownIcon, XIcon } from "lucide-react";

--- a/frontend/src/components/filters/FilterBar.jsx
+++ b/frontend/src/components/filters/FilterBar.jsx
@@ -4,7 +4,7 @@
  * @component FilterBar
  * @description Comprehensive filter bar with search, dropdown filters, date range, and clear all functionality
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { FilterIcon, XIcon } from "lucide-react";

--- a/frontend/src/components/filters/SearchInput.jsx
+++ b/frontend/src/components/filters/SearchInput.jsx
@@ -4,7 +4,7 @@
  * @component SearchInput
  * @description Reusable search input component with clear button and customizable placeholder for filtering data
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { SearchIcon, XIcon } from "lucide-react";

--- a/frontend/src/components/filters/SortableHeader.jsx
+++ b/frontend/src/components/filters/SortableHeader.jsx
@@ -4,7 +4,7 @@
  * @component SortableHeader
  * @description Sortable table header component with visual indicators for column sorting
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { ChevronUpIcon, ChevronDownIcon, ChevronsUpDownIcon } from "lucide-react";

--- a/frontend/src/components/forms/BookBasicFields.jsx
+++ b/frontend/src/components/forms/BookBasicFields.jsx
@@ -4,7 +4,7 @@
  * @component BookBasicFields
  * @description Reusable form component for basic book fields (title, description, category)
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/forms/DocumentBasicFields.jsx
+++ b/frontend/src/components/forms/DocumentBasicFields.jsx
@@ -4,7 +4,7 @@
  * @component DocumentBasicFields
  * @description Reusable form component for basic document fields (title, description, author, category, review date)
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { Controller } from "react-hook-form";

--- a/frontend/src/components/forms/DocumentSelection.jsx
+++ b/frontend/src/components/forms/DocumentSelection.jsx
@@ -4,7 +4,7 @@
  * @component DocumentSelection
  * @description Reusable component for selecting documents using TeamDetailPage pattern with table-based selection
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/components/forms/EnhancedDocumentFields.jsx
+++ b/frontend/src/components/forms/EnhancedDocumentFields.jsx
@@ -4,7 +4,7 @@
  * @component EnhancedDocumentFields
  * @description Enhanced form component for document fields with new review system
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { Controller } from "react-hook-form";

--- a/frontend/src/components/forms/ExternalContactsManager.jsx
+++ b/frontend/src/components/forms/ExternalContactsManager.jsx
@@ -4,7 +4,7 @@
  * @component ExternalContactsManager
  * @description Reusable component for managing external contacts with add, edit, and remove functionality
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { X, Plus, Edit2, Check, XCircle } from "lucide-react";

--- a/frontend/src/components/forms/ReviewAssignments.jsx
+++ b/frontend/src/components/forms/ReviewAssignments.jsx
@@ -4,7 +4,7 @@
  * @component ReviewAssignments
  * @description Reusable component for managing document review assignments with date scheduling and notes
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { Controller } from "react-hook-form";

--- a/frontend/src/components/forms/StakeholderSelection.jsx
+++ b/frontend/src/components/forms/StakeholderSelection.jsx
@@ -4,7 +4,7 @@
  * @component StakeholderSelection
  * @description Reusable component for selecting stakeholders and owners with chip-based UI
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { X } from "lucide-react";

--- a/frontend/src/components/modals/ConfirmationModal.jsx
+++ b/frontend/src/components/modals/ConfirmationModal.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/components/modals/ConfirmationModal.jsx
  * @component ConfirmationModal
  * @description A reusable confirmation modal component for confirming user actions
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import React from 'react';

--- a/frontend/src/components/projects/AddCollaboratorModal.jsx
+++ b/frontend/src/components/projects/AddCollaboratorModal.jsx
@@ -4,7 +4,7 @@
  * @component AddCollaboratorModal
  * @description Modal component for adding collaborators to a project
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/projects/CollaboratorCard.jsx
+++ b/frontend/src/components/projects/CollaboratorCard.jsx
@@ -4,7 +4,7 @@
  * @component CollaboratorCard
  * @description Card component for displaying project collaborators
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { MoreVerticalIcon, UserIcon, MailIcon, PhoneIcon } from 'lucide-react';

--- a/frontend/src/components/projects/ProjectBooksTable.jsx
+++ b/frontend/src/components/projects/ProjectBooksTable.jsx
@@ -4,7 +4,7 @@
  * @component ProjectBooksTable
  * @description Specialized table component for managing books in projects with checkbox selection and bulk actions
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/projects/ProjectCard.jsx
+++ b/frontend/src/components/projects/ProjectCard.jsx
@@ -4,7 +4,7 @@
  * @component ProjectCard
  * @description Project card component displaying project summary, status, priority, and quick actions
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/components/projects/ProjectDocumentsTable.jsx
+++ b/frontend/src/components/projects/ProjectDocumentsTable.jsx
@@ -4,7 +4,7 @@
  * @component ProjectDocumentsTable
  * @description Specialized table component for managing documents in projects with checkbox selection and bulk actions
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/shared/BaseModal.jsx
+++ b/frontend/src/components/shared/BaseModal.jsx
@@ -4,7 +4,7 @@
  * @component BaseModal
  * @description Reusable base modal component with consistent styling and behavior
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useEffect } from "react";

--- a/frontend/src/components/shared/BaseModal.stories.jsx
+++ b/frontend/src/components/shared/BaseModal.stories.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/components/shared/BaseModal.stories.jsx
  * @description Storybook stories for BaseModal component
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState } from 'react';

--- a/frontend/src/components/shared/DataTable.jsx
+++ b/frontend/src/components/shared/DataTable.jsx
@@ -4,7 +4,7 @@
  * @component DataTable
  * @description Reusable data table component with sorting, pagination, and action buttons
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState } from "react";

--- a/frontend/src/components/shared/DataTable.stories.jsx
+++ b/frontend/src/components/shared/DataTable.stories.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/components/shared/DataTable.stories.jsx
  * @description Storybook stories for DataTable component
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState } from 'react';

--- a/frontend/src/components/shared/ErrorBoundary.jsx
+++ b/frontend/src/components/shared/ErrorBoundary.jsx
@@ -4,7 +4,7 @@
  * @component ErrorBoundary
  * @description React error boundary component for graceful error handling and user feedback
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { Component } from "react";

--- a/frontend/src/components/shared/FormField.jsx
+++ b/frontend/src/components/shared/FormField.jsx
@@ -4,7 +4,7 @@
  * @component FormField
  * @description Reusable form field component with consistent styling, validation, and error handling
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import PropTypes from "prop-types";

--- a/frontend/src/components/shared/FormField.stories.jsx
+++ b/frontend/src/components/shared/FormField.stories.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/components/shared/FormField.stories.jsx
  * @description Storybook stories for FormField component
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState } from 'react';

--- a/frontend/src/components/shared/FormModal.jsx
+++ b/frontend/src/components/shared/FormModal.jsx
@@ -4,7 +4,7 @@
  * @component FormModal
  * @description Reusable form modal component with validation, loading states, and error handling
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import PropTypes from "prop-types";

--- a/frontend/src/components/shared/LoadingSpinner.jsx
+++ b/frontend/src/components/shared/LoadingSpinner.jsx
@@ -4,7 +4,7 @@
  * @component LoadingSpinner
  * @description Reusable loading spinner component with various sizes and styles
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import PropTypes from "prop-types";

--- a/frontend/src/components/shared/LoadingSpinner.stories.jsx
+++ b/frontend/src/components/shared/LoadingSpinner.stories.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/components/shared/LoadingSpinner.stories.jsx
  * @description Storybook stories for LoadingSpinner component
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import LoadingSpinner from './LoadingSpinner';

--- a/frontend/src/components/shared/index.js
+++ b/frontend/src/components/shared/index.js
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/components/shared/index.js
  * @description Centralized export for all shared/reusable components
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/system/ConfirmActionModal.jsx
+++ b/frontend/src/components/system/ConfirmActionModal.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/components/system/ConfirmActionModal.jsx
  * @component ConfirmActionModal
  * @description Confirmation modal for dangerous system actions
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import PropTypes from "prop-types";

--- a/frontend/src/components/system/DangerZone.jsx
+++ b/frontend/src/components/system/DangerZone.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/components/system/DangerZone.jsx
  * @component DangerZone
  * @description Danger zone section for system administration with collection clearing and restoration
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState } from "react";

--- a/frontend/src/components/teams/AddMembersModal.jsx
+++ b/frontend/src/components/teams/AddMembersModal.jsx
@@ -4,7 +4,7 @@
  * @component AddMembersModal
  * @description Modal component for adding existing users to a team
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/components/teams/CreateTeamModal.jsx
+++ b/frontend/src/components/teams/CreateTeamModal.jsx
@@ -4,7 +4,7 @@
  * @component CreateTeamModal
  * @description Modal component for creating new teams with form validation and member invitation
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState } from "react";

--- a/frontend/src/components/teams/InviteMemberModal.jsx
+++ b/frontend/src/components/teams/InviteMemberModal.jsx
@@ -4,7 +4,7 @@
  * @component InviteMemberModal
  * @description Modal component for inviting new members to teams with role assignment
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState } from "react";

--- a/frontend/src/components/teams/MemberCard.jsx
+++ b/frontend/src/components/teams/MemberCard.jsx
@@ -4,7 +4,7 @@
  * @component MemberCard
  * @description Card component for displaying team member information
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { MoreVerticalIcon, UserIcon, CrownIcon, ShieldIcon } from "lucide-react";

--- a/frontend/src/components/teams/TeamBooksTable.jsx
+++ b/frontend/src/components/teams/TeamBooksTable.jsx
@@ -4,7 +4,7 @@
  * @component TeamBooksTable
  * @description Specialized table component for managing books in teams with checkbox selection and bulk actions
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/teams/TeamCard.jsx
+++ b/frontend/src/components/teams/TeamCard.jsx
@@ -4,7 +4,7 @@
  * @component TeamCard
  * @description Team card component displaying team info, member count, project count, and management actions
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/components/teams/TeamDocumentsTable.jsx
+++ b/frontend/src/components/teams/TeamDocumentsTable.jsx
@@ -4,7 +4,7 @@
  * @component TeamDocumentsTable
  * @description Specialized table component for managing documents in teams with checkbox selection and bulk actions
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/teams/TeamProjectsTable.jsx
+++ b/frontend/src/components/teams/TeamProjectsTable.jsx
@@ -4,7 +4,7 @@
  * @component TeamProjectsTable
  * @description Specialized table component for managing projects in teams with checkbox selection and bulk actions
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 

--- a/frontend/src/context/ConfirmationContext.jsx
+++ b/frontend/src/context/ConfirmationContext.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/context/ConfirmationContext.jsx
  * @context ConfirmationContext
  * @description Context provider for confirmation modals
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { createContext, useContext } from 'react';

--- a/frontend/src/context/ThemeContext.jsx
+++ b/frontend/src/context/ThemeContext.jsx
@@ -4,7 +4,7 @@
  * @context ThemeContext
  * @description React context for managing application theme state with persistence and user preferences
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { createContext, useContext, useState, useEffect } from "react";

--- a/frontend/src/hooks/index.js
+++ b/frontend/src/hooks/index.js
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/hooks/index.js
  * @description Centralized export for all custom React hooks
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 

--- a/frontend/src/hooks/useApi.js
+++ b/frontend/src/hooks/useApi.js
@@ -4,7 +4,7 @@
  * @hook useApi
  * @description Custom hook for managing API operations with loading states and error handling
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState, useCallback } from "react";

--- a/frontend/src/hooks/useAutoLogout.jsx
+++ b/frontend/src/hooks/useAutoLogout.jsx
@@ -15,7 +15,7 @@
  *                     Defaults to 15 minutes.
  *
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 // hooks/useAutoLogout.js

--- a/frontend/src/hooks/useConfirmation.js
+++ b/frontend/src/hooks/useConfirmation.js
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/hooks/useConfirmation.js
  * @hook useConfirmation
  * @description Custom hook for handling confirmation modals
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState, useCallback } from 'react';

--- a/frontend/src/hooks/useDocument.js
+++ b/frontend/src/hooks/useDocument.js
@@ -4,7 +4,7 @@
  * @hook useDocument
  * @description Custom hook for loading and managing document data
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState, useEffect, useCallback } from "react";

--- a/frontend/src/hooks/useDocumentManagement.js
+++ b/frontend/src/hooks/useDocumentManagement.js
@@ -4,7 +4,7 @@
  * @hook useDocumentManagement
  * @description Custom hook for managing document selection in book forms
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState, useCallback } from "react";

--- a/frontend/src/hooks/useExternalContacts.js
+++ b/frontend/src/hooks/useExternalContacts.js
@@ -4,7 +4,7 @@
  * @hook useExternalContacts
  * @description Custom hook for managing external contacts in document forms
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState, useCallback } from "react";

--- a/frontend/src/hooks/useFileUpload.js
+++ b/frontend/src/hooks/useFileUpload.js
@@ -4,7 +4,7 @@
  * @hook useFileUpload
  * @description Custom hook for managing file upload state and progress
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState, useCallback } from "react";

--- a/frontend/src/hooks/useFormData.js
+++ b/frontend/src/hooks/useFormData.js
@@ -4,7 +4,7 @@
  * @hook useFormData
  * @description Custom hook for loading common form data (users, categories, external contact types)
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/hooks/useReviewAssignments.js
+++ b/frontend/src/hooks/useReviewAssignments.js
@@ -4,7 +4,7 @@
  * @hook useReviewAssignments
  * @description Custom hook for managing document review assignments and completion status
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState, useEffect, useCallback } from "react";

--- a/frontend/src/hooks/useReviewManagement.js
+++ b/frontend/src/hooks/useReviewManagement.js
@@ -4,7 +4,7 @@
  * @hook useReviewManagement
  * @description Custom hook for managing document review assignments and scheduling
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState, useCallback } from "react";

--- a/frontend/src/hooks/useStakeholderManagement.js
+++ b/frontend/src/hooks/useStakeholderManagement.js
@@ -4,7 +4,7 @@
  * @hook useStakeholderManagement
  * @description Custom hook for managing stakeholders and owners in document forms
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState, useCallback } from "react";

--- a/frontend/src/hooks/useUserRole.js
+++ b/frontend/src/hooks/useUserRole.js
@@ -4,7 +4,7 @@
  * @hook useUserRole
  * @description Custom hook for managing user authentication and role state
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState, useEffect, useCallback } from "react";

--- a/frontend/src/lib/axios.js
+++ b/frontend/src/lib/axios.js
@@ -4,7 +4,7 @@
  * @module AxiosConfig
  * @description Axios HTTP client configuration with base URL, interceptors, and authentication headers
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import axios from "axios";

--- a/frontend/src/lib/documentFormSchema.js
+++ b/frontend/src/lib/documentFormSchema.js
@@ -4,7 +4,7 @@
  * @module documentFormSchema
  * @description Shared validation schemas and constants for document forms
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { z } from "zod";

--- a/frontend/src/lib/globalUtils.js
+++ b/frontend/src/lib/globalUtils.js
@@ -4,7 +4,7 @@
  * @module globalUtils
  * @description Global utility functions for common operations across the application
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 // frontend/src/lib/globalUtils.js

--- a/frontend/src/lib/safeUtils.js
+++ b/frontend/src/lib/safeUtils.js
@@ -4,7 +4,7 @@
  * @module safeUtils
  * @description Safe utility functions to prevent common React errors. These functions ensure data is always in the expected format
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -4,7 +4,7 @@
  * @module utils
  * @description Backend utility functions for object validation and common server-side operations
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 /**

--- a/frontend/src/lib/validation.js
+++ b/frontend/src/lib/validation.js
@@ -4,7 +4,7 @@
  * @module validation
  * @description Form validation utilities with comprehensive validation rules and error handling
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 /**

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { StrictMode } from 'react';

--- a/frontend/src/pages/AdminProjectsPage.jsx
+++ b/frontend/src/pages/AdminProjectsPage.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/pages/AdminProjectsPage.jsx
  * @page AdminProjectsPage
  * @description Admin page for managing all projects in the system
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/AdminTeamsPage.jsx
+++ b/frontend/src/pages/AdminTeamsPage.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/pages/AdminTeamsPage.jsx
  * @page AdminTeamsPage
  * @description Admin page for managing all teams in the system
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/AnalyticsPage.jsx
+++ b/frontend/src/pages/AnalyticsPage.jsx
@@ -4,7 +4,7 @@
  * @page AnalyticsPage
  * @description Analytics dashboard with charts and metrics for document management insights and reporting
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/CreateBookPage.jsx
+++ b/frontend/src/pages/CreateBookPage.jsx
@@ -4,7 +4,7 @@
  * @page CreateBookPage
  * @description Book creation page with form for adding new books using shared design patterns
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState } from "react";

--- a/frontend/src/pages/CreateCatPage.jsx
+++ b/frontend/src/pages/CreateCatPage.jsx
@@ -4,7 +4,7 @@
  * @page CreateCatPage
  * @description Category creation page with form for adding new document categories
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState } from "react";

--- a/frontend/src/pages/CreateDocPage.jsx
+++ b/frontend/src/pages/CreateDocPage.jsx
@@ -4,7 +4,7 @@
  * @page CreateDocPage
  * @description Document creation page with form for uploading files, setting metadata, assigning stakeholders and owners
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useNavigate, Link } from "react-router";

--- a/frontend/src/pages/CreateProjectPage.jsx
+++ b/frontend/src/pages/CreateProjectPage.jsx
@@ -4,7 +4,7 @@
  * @page CreateProjectPage
  * @description Project creation page with form for setting up new projects and team assignments
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/CustomChartsPage.jsx
+++ b/frontend/src/pages/CustomChartsPage.jsx
@@ -4,7 +4,7 @@
  * @page CustomChartPage
  * @description Custom analytics page for creating and viewing personalized data visualizations
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/EditBookPage.jsx
+++ b/frontend/src/pages/EditBookPage.jsx
@@ -4,7 +4,7 @@
  * @page EditBookPage
  * @description Book editing page with form for updating existing books using shared design patterns
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useNavigate, useParams, Link } from "react-router";

--- a/frontend/src/pages/EditCatPage.jsx
+++ b/frontend/src/pages/EditCatPage.jsx
@@ -4,7 +4,7 @@
  * @page EditCatPage
  * @description Category editing page with form for updating existing categories
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/EditDocPage.jsx
+++ b/frontend/src/pages/EditDocPage.jsx
@@ -4,7 +4,7 @@
  * @page EditDocPage
  * @description Document editing page with form validation for updating document metadata, stakeholders, and file versions
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/pages/EditProjectPage.jsx
+++ b/frontend/src/pages/EditProjectPage.jsx
@@ -4,7 +4,7 @@
  * @page EditProjectPage
  * @description Project editing page for updating project details, status, and team members
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/EditTeamPage.jsx
+++ b/frontend/src/pages/EditTeamPage.jsx
@@ -4,7 +4,7 @@
  * @page EditTeamPage
  * @description Team editing page for updating team information and managing member roles
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/ForgotPassPage.jsx
+++ b/frontend/src/pages/ForgotPassPage.jsx
@@ -4,7 +4,7 @@
  * @page ForgotPassPage
  * @description Page component for password reset request functionality
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import React, { useState } from "react";

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -4,7 +4,7 @@
  * @page HomePage
  * @description Main dashboard page displaying document overview, recent documents, and quick access to key features
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -4,7 +4,7 @@
  * @page LoginPage
  * @description Page for user authentication and login.
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 

--- a/frontend/src/pages/ManageExternalContactTypesPage.jsx
+++ b/frontend/src/pages/ManageExternalContactTypesPage.jsx
@@ -4,7 +4,7 @@
  * @page ManageExternalContactTypesPage
  * @description External contact type management page for organizing contact categories
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/pages/MyProfilePage.jsx
+++ b/frontend/src/pages/MyProfilePage.jsx
@@ -4,7 +4,7 @@
  * @page MyProfilePage
  * @description User profile management page for updating personal information and preferences
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/pages/ProjectDetailPage.jsx
+++ b/frontend/src/pages/ProjectDetailPage.jsx
@@ -4,7 +4,7 @@
  * @page ProjectDetailPage
  * @description Project detail page showing project information, documents, and team collaboration
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/pages/ProjectSettingsPage.jsx
+++ b/frontend/src/pages/ProjectSettingsPage.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/pages/ProjectSettingsPage.jsx
  * @page ProjectSettingsPage
  * @description Project settings page for managing project configuration and preferences
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/ProjectsPage.jsx
+++ b/frontend/src/pages/ProjectsPage.jsx
@@ -4,7 +4,7 @@
  * @page ProjectsPage
  * @description Project management page with filtering, search, and project creation for organizing documents by project
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/pages/RegUserPage.jsx
+++ b/frontend/src/pages/RegUserPage.jsx
@@ -4,7 +4,7 @@
  * @page RegUserPage
  * @description User registration page with form validation and account creation functionality
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState } from "react";

--- a/frontend/src/pages/ResetPassPage.jsx
+++ b/frontend/src/pages/ResetPassPage.jsx
@@ -4,7 +4,7 @@
  * @page ResetPassPage
  * @description Password reset page for updating user passwords with secure token validation
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 // ResetPasswordForm.jsx

--- a/frontend/src/pages/SystemInfoPage.jsx
+++ b/frontend/src/pages/SystemInfoPage.jsx
@@ -4,7 +4,7 @@
  * @page SystemInfoPage
  * @description System information dashboard displaying server status, database info, and application metrics
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/pages/TeamDetailPage.jsx
+++ b/frontend/src/pages/TeamDetailPage.jsx
@@ -4,7 +4,7 @@
  * @page TeamDetailPage
  * @description Team detail page displaying team members, projects, and collaboration tools
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/pages/TeamSettingsPage.jsx
+++ b/frontend/src/pages/TeamSettingsPage.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/pages/TeamSettingsPage.jsx
  * @page TeamSettingsPage
  * @description Team settings page for managing team configuration and preferences
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/TeamsPage.jsx
+++ b/frontend/src/pages/TeamsPage.jsx
@@ -4,7 +4,7 @@
  * @page TeamsPage
  * @description Team management page displaying user teams with creation, editing, and member management capabilities
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/pages/ViewBookPage.jsx
+++ b/frontend/src/pages/ViewBookPage.jsx
@@ -4,7 +4,7 @@
  * @page ViewBookPage
  * @description Individual book view page showing book details and contained documents
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/ViewBooksPage.jsx
+++ b/frontend/src/pages/ViewBooksPage.jsx
@@ -4,7 +4,7 @@
  * @page ViewBooksPage
  * @description Books listing page with filtering and management capabilities
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import React, { useState, useEffect } from 'react';

--- a/frontend/src/pages/ViewCatsPage.jsx
+++ b/frontend/src/pages/ViewCatsPage.jsx
@@ -4,7 +4,7 @@
  * @page ViewCatsPage
  * @description Category management page for viewing, creating, and organizing document categories
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/pages/ViewDocPage.jsx
+++ b/frontend/src/pages/ViewDocPage.jsx
@@ -4,7 +4,7 @@
  * @page ViewDocPage
  * @description Document detail page displaying document information, version history, file downloads, and review management
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { Link, useNavigate, useParams } from "react-router";

--- a/frontend/src/pages/ViewDocsPage.jsx
+++ b/frontend/src/pages/ViewDocsPage.jsx
@@ -4,7 +4,7 @@
  * @page ViewDocsPage
  * @description Document listing page with search, filtering, sorting, and bulk operations for managing documents
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/pages/ViewUserPage.jsx
+++ b/frontend/src/pages/ViewUserPage.jsx
@@ -4,7 +4,7 @@
  * @page ViewUserPage
  * @description User detail page displaying user information and administrative actions
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/pages/ViewUsersPage.jsx
+++ b/frontend/src/pages/ViewUsersPage.jsx
@@ -4,7 +4,7 @@
  * @page ViewUsersPage
  * @description User management page with filtering, search, and user administration for system administrators
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/themes.js
+++ b/frontend/src/themes.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 // Theme definitions for the application

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rd-docman",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rd-docman",
-      "version": "2.2.4",
+      "version": "2.2.5",
       "license": "UNLICENSED",
       "devDependencies": {
         "@playwright/test": "^1.42.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rdocman",
   "private": true,
-  "version": "2.2.4",
+  "version": "2.2.5",
   "type": "module",
   "description": "RDocMan is a document management application for all sorts of documents. Track updates, schedule reviews, categorize, and upload versions of your docs. DocMan hopes to be the most comprehensive piece of software to manage all of your documentation. You can schedule your documentation for review between stakeholders, the original authors, contributors, relevant tech leads, etc... Categorize, analyze, version repositories, and basically everything you would need to keep your documentation well organized, maintained, analyzed, and backed up.",
   "keywords": [

--- a/project-config.json
+++ b/project-config.json
@@ -1,5 +1,5 @@
 {
   "author": "Richard Bakos",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "license": "UNLICENSED"
 }

--- a/scripts/apache_production_deploy.sh
+++ b/scripts/apache_production_deploy.sh
@@ -45,6 +45,11 @@ SERVICE_USER=docman
 SERVICE_GROUP=www-data
 MIN_NODE_VERSION=20.19.0
 ENV_SOURCE_FILE=""
+OPERATOR_USER="${SUDO_USER:-${USER:-root}}"
+OPERATOR_HOME="$(getent passwd "$OPERATOR_USER" | cut -d: -f6 2>/dev/null || true)"
+OPERATOR_HOME="${OPERATOR_HOME:-$HOME}"
+ENV_EXPORT_DIR="$OPERATOR_HOME/docman"
+EXPORTED_ENV_SOURCE_FILE="$ENV_EXPORT_DIR/previous-backend.env.prod"
 
 # --- Functions ---
 rollback() {
@@ -65,17 +70,27 @@ ask() {
 }
 
 detect_previous_env_source() {
-    local candidates=()
     local latest_backup
 
-    if [[ -f "$BACKEND_DIR/.env.prod" ]]; then
-        ENV_SOURCE_FILE="$BACKEND_DIR/.env.prod"
+    if [[ -f "$EXPORTED_ENV_SOURCE_FILE" ]]; then
+        ENV_SOURCE_FILE="$EXPORTED_ENV_SOURCE_FILE"
+        return
+    fi
+
+    latest_backup=$(ls -dt "$ENV_EXPORT_DIR"/env-backups/* 2>/dev/null | head -n1 || true)
+    if [[ -n "$latest_backup" && -f "$latest_backup/backend/.env.prod" ]]; then
+        ENV_SOURCE_FILE="$latest_backup/backend/.env.prod"
         return
     fi
 
     latest_backup=$(ls -dt /var/www/docman_bak_* 2>/dev/null | head -n1 || true)
     if [[ -n "$latest_backup" && -f "$latest_backup/backend/.env.prod" ]]; then
         ENV_SOURCE_FILE="$latest_backup/backend/.env.prod"
+        return
+    fi
+
+    if [[ -f "$BACKEND_DIR/.env.prod" ]]; then
+        ENV_SOURCE_FILE="$BACKEND_DIR/.env.prod"
         return
     fi
 
@@ -123,8 +138,42 @@ backup_if_exists() {
     if [[ -e "$target" ]]; then
         local backup_path="${target}_bak_$(date +%F_%H%M%S)"
         echo "⚠️ Existing path detected at $target"
+        export_env_files_from_target "$target"
         echo "🔄 Backing it up to $backup_path"
         mv "$target" "$backup_path"
+    fi
+}
+
+export_env_files_from_target() {
+    local target="$1"
+    local snapshot_root="$ENV_EXPORT_DIR/env-backups/$(basename "$target")_$(date +%F_%H%M%S)"
+    local found_env=false
+
+    [[ -d "$target" ]] || return 0
+
+    mkdir -p "$snapshot_root"
+    mkdir -p "$ENV_EXPORT_DIR"
+
+    while IFS= read -r -d '' env_file; do
+        local rel_path="${env_file#$target/}"
+        local dest_dir="$snapshot_root/$(dirname "$rel_path")"
+
+        mkdir -p "$dest_dir"
+        cp "$env_file" "$dest_dir/"
+        found_env=true
+
+        if [[ "$rel_path" == "backend/.env.prod" ]]; then
+            cp "$env_file" "$EXPORTED_ENV_SOURCE_FILE"
+        fi
+    done < <(find "$target" -maxdepth 4 -type f -name '.env*' -print0 2>/dev/null)
+
+    if [[ "$found_env" == true ]]; then
+        echo "📦 Exported previous .env files to $snapshot_root"
+        if [[ -f "$EXPORTED_ENV_SOURCE_FILE" ]]; then
+            echo "🔍 Preserved backend env defaults at $EXPORTED_ENV_SOURCE_FILE"
+        fi
+    else
+        rmdir "$snapshot_root" 2>/dev/null || true
     fi
 }
 

--- a/scripts/apache_production_update.sh
+++ b/scripts/apache_production_update.sh
@@ -1,143 +1,194 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
-# ==============================================
-# === DocMan Production Update Script (Full) ===
-# ==============================================
+# ================================================================
+# === DocMan Production Update Script (Interactive / Modernized) ===
+# ================================================================
 #
-# This script performs a full update of the DocMan project.
+# This script updates an existing Apache-hosted DocMan deployment.
 #
-# It includes:
-# - Backing up current .env.prod and frontend files
-# - Clearing out the /var/www/docman directory and cloning a fresh copy of the repository
-# - Building the application using npm
-# - Merging any new environment variables from .env.sample into .env.prod
-# - Restarting the backend service with systemd
-# - Updating the Apache frontend configuration
-# - Optionally updating SSL certificates using Certbot
-#
-# After completion, there is an option to rollback changes if something goes wrong.
+# It performs the following high-level steps:
+# - preserves the current backend env and frontend publish root
+# - exports previous .env files into ~/docman/env-backups for recovery
+# - replaces /var/www/docman with a fresh clone
+# - rebuilds the Vue frontend and the remote bundle
+# - restores and normalizes .env.prod
+# - republishes the frontend and remote assets
+# - restarts the backend service and reloads Apache
+# - optionally runs Certbot for one or more domains
 #
 # Usage:
-#   ./apache_production_update.sh
-#
-# Notes:
-# - The script assumes you have already set up your environment variables (.env.prod).
-# - If no backup is found, it creates a new one based on .env.sample
-#
-# Author: Richard Bakos <resonance.designs.com@gmail.com>
-# Organization: Resonance Designs
-# Website: https://resonancedesigns.dev
-# GitHub: https://github.com/resonance-designs
-# Date: 2025-09-24
+#   sudo ./apache_production_update.sh
 
-# --- Functions ---
-rollback() {
-    echo "⚠️ Rolling back update..."
-    # Restore backend
-    rm -rf /var/www/docman
-    mkdir -p /var/www/docman
-    chown -R www-data:www-data /var/www/docman
-    git clone https://github.com/resonance-designs/docman.git /var/www/docman
-    cd /var/www/docman/backend
-    if [[ -f /tmp/docman_env_backup/.env.prod ]]; then
-        cp /tmp/docman_env_backup/.env.prod .env.prod
-        echo "✅ Backend .env.prod restored."
+DEPLOY_ROOT=/var/www/docman
+BACKEND_DIR="$DEPLOY_ROOT/backend"
+VUE_FRONTEND_DIR="$DEPLOY_ROOT/frontend-vue"
+APACHE_ROOT=/var/www/html
+SERVICE_FILE=/etc/systemd/system/docman-backend.service
+SERVICE_USER=docman
+SERVICE_GROUP=www-data
+MIN_NODE_VERSION=20.19.0
+BACKUP_ROOT=/tmp/docman_env_backup
+FRONTEND_FOLDER_DEFAULT=docman
+OPERATOR_USER="${SUDO_USER:-${USER:-root}}"
+OPERATOR_HOME="$(getent passwd "$OPERATOR_USER" | cut -d: -f6 2>/dev/null || true)"
+OPERATOR_HOME="${OPERATOR_HOME:-$HOME}"
+ENV_EXPORT_DIR="$OPERATOR_HOME/docman"
+EXPORTED_ENV_SOURCE_FILE="$ENV_EXPORT_DIR/previous-backend.env.prod"
+
+version_ge() {
+    local current="$1"
+    local minimum="$2"
+    [[ "$(printf '%s\n%s\n' "$minimum" "$current" | sort -V | head -n1)" == "$minimum" ]]
+}
+
+check_prerequisites() {
+    if ! command -v node >/dev/null 2>&1; then
+        echo "⚠️ Node.js is not installed."
+        exit 1
     fi
-    # Restore frontend
-    frontend_folder_default="docman"
-    read -p "Enter frontend folder name to restore [$frontend_folder_default]: " frontend_folder
-    frontend_folder=${frontend_folder:-$frontend_folder_default}
-    rsync -a --delete /tmp/docman_env_backup/public_html_backup/ /var/www/html/$frontend_folder/public_html/
-    chown -R www-data:www-data /var/www/html/$frontend_folder/public_html
-    # Restart services
-    systemctl restart docman-backend.service
-    systemctl reload apache2
-    echo "✅ Update rolled back successfully."
-    exit 0
+
+    local node_version
+    node_version=$(node -v | sed 's/^v//')
+    if ! version_ge "$node_version" "$MIN_NODE_VERSION"; then
+        echo "⚠️ Node.js $node_version found, but DocMan requires >= $MIN_NODE_VERSION for the current Vue/Vite build."
+        exit 1
+    fi
+
+    command -v git >/dev/null 2>&1 || { echo "⚠️ Git is required."; exit 1; }
+    command -v rsync >/dev/null 2>&1 || { echo "⚠️ rsync is required."; exit 1; }
 }
 
-mask_sensitive() {
-    local var_value="$1"
-    [[ -z "$var_value" ]] && echo "null" || echo "${var_value:0:3}***"
-}
+export_env_files_from_target() {
+    local target="$1"
+    local snapshot_root="$ENV_EXPORT_DIR/env-backups/$(basename "$target")_$(date +%F_%H%M%S)"
+    local found_env=false
 
-ask() {
-    local var_name=$1
-    local prompt=$2
-    local default=$3
-    local value
-    read -p "$prompt [$default]: " value
-    value=${value:-$default}
-    sed -i "s|^$var_name=.*|$var_name=$value|" .env.prod
+    [[ -d "$target" ]] || return 0
+
+    mkdir -p "$snapshot_root"
+    mkdir -p "$ENV_EXPORT_DIR"
+
+    while IFS= read -r -d '' env_file; do
+        local rel_path="${env_file#$target/}"
+        local dest_dir="$snapshot_root/$(dirname "$rel_path")"
+        mkdir -p "$dest_dir"
+        cp "$env_file" "$dest_dir/"
+        found_env=true
+
+        if [[ "$rel_path" == "backend/.env.prod" ]]; then
+            cp "$env_file" "$EXPORTED_ENV_SOURCE_FILE"
+        fi
+    done < <(find "$target" -maxdepth 4 -type f -name '.env*' -print0 2>/dev/null)
+
+    if [[ "$found_env" == true ]]; then
+        echo "📦 Exported previous .env files to $snapshot_root"
+        [[ -f "$EXPORTED_ENV_SOURCE_FILE" ]] && echo "🔍 Preserved backend env defaults at $EXPORTED_ENV_SOURCE_FILE"
+    else
+        rmdir "$snapshot_root" 2>/dev/null || true
+    fi
 }
 
 merge_env() {
-    # Merge new variables from .env.sample into .env.prod if missing
-    for key in $(grep -v '^#' .env.sample | cut -d= -f1); do
-        if ! grep -q "^$key=" .env.prod; then
-            val=$(grep "^$key=" .env.sample | cut -d= -f2-)
-            echo "$key=$val" >> .env.prod
+    while IFS= read -r key; do
+        [[ -z "$key" ]] && continue
+        if ! grep -q "^${key}=" .env.prod; then
+            local value
+            value=$(grep "^${key}=" .env.sample | cut -d= -f2-)
+            echo "${key}=${value}" >> .env.prod
         fi
-    done
+    done < <(grep -v '^#' .env.sample | cut -d= -f1)
 }
 
-# --- Update Start ---
-echo "==================================================="
-echo "=== Updating DocMan on Apache Production Server ==="
-echo "==================================================="
-echo ""
+publish_frontend_assets() {
+    local frontend_folder="$1"
+    local publish_root="$APACHE_ROOT/$frontend_folder"
 
-# --- Root check ---
+    mkdir -p "$publish_root/public_html"
+    mkdir -p "$publish_root/public_html/remote"
+    mkdir -p "$publish_root/logs"
+
+    rsync -a --delete "$VUE_FRONTEND_DIR/dist/" "$publish_root/public_html/"
+    rsync -a --delete "$VUE_FRONTEND_DIR/dist-remote/remote/" "$publish_root/public_html/remote/"
+    chown -R www-data:www-data "$publish_root"
+}
+
+rollback() {
+    echo "⚠️ Rolling back update..."
+
+    rm -rf "$DEPLOY_ROOT"
+    git clone https://github.com/resonance-designs/docman.git "$DEPLOY_ROOT"
+
+    if [[ -f "$BACKUP_ROOT/.env.prod" ]]; then
+        cp "$BACKUP_ROOT/.env.prod" "$BACKEND_DIR/.env.prod"
+        echo "✅ Backend .env.prod restored."
+    fi
+
+    if [[ -d "$BACKUP_ROOT/public_html_backup" ]]; then
+        rsync -a --delete "$BACKUP_ROOT/public_html_backup/" "$APACHE_ROOT/$frontend_folder/public_html/"
+    fi
+
+    systemctl restart docman-backend.service
+    systemctl reload apache2
+    echo "✅ Update rolled back successfully."
+    exit 1
+}
+
+trap 'echo "❌ Error detected during update."; rollback' ERR
+
 if [[ $EUID -ne 0 ]]; then
     echo "⚠️ This script must be run as root."
     exit 1
 fi
 
-echo "This update script does the following:"
-echo "- Backs up current .env.prod and frontend"
-echo "- Clears /var/www/docman and clones fresh repository"
-echo "- Builds the application"
-echo "- Updates environment variables"
-echo "- Restarts backend service"
-echo "- Updates Apache frontend"
-echo "- Optionally updates SSL certificates"
-echo "- Provides a rollback option at the end"
+check_prerequisites
+
+frontend_folder="$FRONTEND_FOLDER_DEFAULT"
+read -p "Enter frontend folder name to update [$FRONTEND_FOLDER_DEFAULT]: " frontend_folder_input
+frontend_folder="${frontend_folder_input:-$FRONTEND_FOLDER_DEFAULT}"
+
+echo "==================================================="
+echo "=== Updating DocMan on Apache Production Server ==="
+echo "==================================================="
+echo ""
+echo "This update script will:"
+echo "- back up the current backend env and frontend publish root"
+echo "- clone a fresh repository into /var/www/docman"
+echo "- rebuild the Vue frontend and remote bundle"
+echo "- restore and normalize .env.prod"
+echo "- restart the backend service and reload Apache"
 echo ""
 
-# --- 1️⃣ Backup existing environment and frontend ---
+# --- 1️⃣ Backup current environment and frontend ---
 echo "1️⃣ Backing up current .env.prod and frontend..."
-mkdir -p /tmp/docman_env_backup
-cp /var/www/docman/backend/.env.prod /tmp/docman_env_backup/.env.prod
-frontend_folder_default="docman"
-read -p "Enter frontend folder name to backup [$frontend_folder_default]: " frontend_folder
-frontend_folder=${frontend_folder:-$frontend_folder_default}
-mkdir -p /tmp/docman_env_backup/public_html_backup
-rsync -a /var/www/html/$frontend_folder/public_html/ /tmp/docman_env_backup/public_html_backup/
+mkdir -p "$BACKUP_ROOT"
+cp "$BACKEND_DIR/.env.prod" "$BACKUP_ROOT/.env.prod"
+mkdir -p "$BACKUP_ROOT/public_html_backup"
+rsync -a "$APACHE_ROOT/$frontend_folder/public_html/" "$BACKUP_ROOT/public_html_backup/"
+export_env_files_from_target "$DEPLOY_ROOT"
 echo "✅ Backup complete."
 
-# --- 2️⃣ Clone fresh repository ---
+# --- 2️⃣ Fresh repository checkout ---
 echo ""
 echo "2️⃣ Cloning fresh repository..."
-rm -rf /var/www/docman
-mkdir -p /var/www/docman
-chown -R www-data:www-data /var/www/docman
-git clone https://github.com/resonance-designs/docman.git /var/www/docman
+rm -rf "$DEPLOY_ROOT"
+git clone https://github.com/resonance-designs/docman.git "$DEPLOY_ROOT"
 echo "✅ Repository cloned fresh."
 
-# --- 3️⃣ Build application ---
+# --- 3️⃣ Build current frontend/runtime ---
 echo ""
-echo "3️⃣ Building application..."
-cd /var/www/docman
-npm run build
+echo "3️⃣ Building Vue frontend and remote bundle..."
+cd "$DEPLOY_ROOT"
+npm run build:vue
+npm run build:remote --prefix frontend-vue
 echo "✅ Build complete."
 
-# --- 4️⃣ Restore and prepare environment ---
+# --- 4️⃣ Restore environment ---
 echo ""
 echo "4️⃣ Restoring previous .env.prod..."
-cd backend
-if [[ -f /tmp/docman_env_backup/.env.prod ]]; then
-    cp /tmp/docman_env_backup/.env.prod .env.prod
+cd "$BACKEND_DIR"
+if [[ -f "$BACKUP_ROOT/.env.prod" ]]; then
+    cp "$BACKUP_ROOT/.env.prod" .env.prod
     echo "✅ .env.prod restored."
 else
     echo "⚠️ No backup found, creating new from sample..."
@@ -148,35 +199,34 @@ sed -i '/^#/d;/^$/d' .env.prod
 sed -i 's/^ACTIVE_ENV=.*/ACTIVE_ENV=1/' .env.prod
 sed -i 's/^ENV=.*/ENV=Production/' .env.prod
 sed -i 's/^NODE_ENV=.*/NODE_ENV=production/' .env.prod
-
 merge_env
 echo "✅ Environment variables updated."
 
-# --- 5️⃣ MongoDB ---
+# --- 5️⃣ Restart MongoDB when local config exists ---
 echo ""
 echo "5️⃣ Restarting MongoDB if configured..."
-MONGO_PORT=$(grep "^MONGO_PORT=" .env.prod | cut -d= -f2-)
+MONGO_PORT=$(grep '^MONGO_PORT=' .env.prod | cut -d= -f2-)
 if [[ -f /etc/mongod.conf ]]; then
     systemctl restart mongod
     echo "⏳ Waiting for MongoDB to start on port $MONGO_PORT..."
-    until nc -z localhost $MONGO_PORT; do sleep 1; done
+    until nc -z localhost "$MONGO_PORT"; do sleep 1; done
     echo "✅ MongoDB restarted."
 fi
 
-# --- 6️⃣ Backend Service Restart ---
-SERVICE_FILE=/etc/systemd/system/docman-backend.service
+# --- 6️⃣ Restart backend service ---
 echo ""
 echo "6️⃣ Restarting DocMan backend service..."
+install -d -o www-data -g www-data -m 775 "$BACKEND_DIR/uploads"
+chown -R "$SERVICE_USER:$SERVICE_GROUP" "$BACKEND_DIR"
 systemctl daemon-reload
 systemctl restart docman-backend.service
 systemctl enable docman-backend.service
 echo "✅ Backend service restarted successfully."
 
-# --- 7️⃣ Apache Frontend ---
+# --- 7️⃣ Publish frontend assets ---
 echo ""
-echo "7️⃣ Updating frontend..."
-rsync -a --delete /var/www/docman/frontend/dist/ /var/www/html/$frontend_folder/public_html/
-chown -R www-data:www-data /var/www/html/$frontend_folder/public_html
+echo "7️⃣ Publishing frontend and remote assets..."
+publish_frontend_assets "$frontend_folder"
 systemctl reload apache2
 echo "✅ Frontend updated successfully."
 
@@ -184,25 +234,23 @@ echo "✅ Frontend updated successfully."
 echo ""
 read -p "8️⃣ Do you want to update SSL certificates via Certbot? (y/n): " update_cert
 if [[ "$update_cert" =~ ^[Yy]$ ]]; then
-    read -p "Enter domain name for SSL (same as previous) [example.com]: " domain_name
-    read -p "Enter email for SSL registration (Let's Encrypt) [admin@$domain_name]: " certbot_email
-    certbot_email=${certbot_email:-admin@$domain_name}
-    certbot --apache -d "$domain_name" --non-interactive --agree-tos -m "$certbot_email"
+    read -p "Enter domains for Certbot (space-separated, e.g. docman.resonancedesigns.dev api.docman.resonancedesigns.dev): " certbot_domains
+    read -p "Enter email for SSL registration (Let's Encrypt): " certbot_email
+
+    if [[ -z "$certbot_domains" || -z "$certbot_email" ]]; then
+        echo "⚠️ Domains and registration email are required for SSL updates."
+        exit 1
+    fi
+
+    certbot_args=()
+    for domain in $certbot_domains; do
+        certbot_args+=("-d" "$domain")
+    done
+
+    certbot --apache --non-interactive --agree-tos -m "$certbot_email" "${certbot_args[@]}"
     systemctl reload apache2
     echo "✅ SSL certificates updated."
-else
-    echo "⚠️ Skipping SSL update."
-    # fallback for final prompt
-    domain_name=${domain_name:-example.com}
 fi
 
-# --- 9️⃣ Post-update rollback option ---
 echo ""
-echo "🚨 Update complete."
-echo "Test that everything is working correctly by visiting $domain_name and confirming all functionality."
-read -p "If not, it is recommended to roll back. Do you want to perform a rollback? (y/n): " do_rollback
-if [[ "$do_rollback" =~ ^[Yy]$ ]]; then
-    rollback
-else
-    echo "🎉 Update finished successfully. No rollback performed."
-fi
+echo "🎉 Update finished successfully."

--- a/scripts/apache_production_update_ni.sh
+++ b/scripts/apache_production_update_ni.sh
@@ -1,46 +1,42 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 # ======================================================================
-# === DocMan Production Non-Interactive Update Script (Optional SSL) ===
+# === DocMan Production Update Script (Non-Interactive / Modernized) ===
 # ======================================================================
 #
-# This script updates the production version of DocMan running on an Apache server.
-#
-# Features:
-# - Performs a non-interactive update to ensure minimal downtime.
-# - Automatically rolls back changes if any error occurs during the update process.
-# - Supports optional SSL certificate renewal using Certbot.
-#
-# Prerequisites:
-# - Requires root access or sudo privileges.
+# This script performs a non-interactive update of an existing Apache-hosted
+# DocMan deployment and automatically rolls back if a command fails.
 #
 # Usage:
-#   ./apache_production_update_ni.sh [--ssl] [--dry-run]
+#   sudo ./apache_production_update_ni.sh [--ssl] [--dry-run]
 #
-# Options:
-#   --ssl      Enable SSL certificate renewal using Certbot.
-#   --dry-run  Perform a dry run without making actual changes. Useful for testing purposes
-#
-# Notes:
-# - The script assumes you have already set up your environment variables (.env.prod).
-# - If no backup is found, it creates a new one based on .env.sample
-#
-# Author: Richard Bakos <resonance.designs.com@gmail.com>
-# Organization: Resonance Designs
-# Website: https://resonancedesigns.dev
-# GitHub: https://github.com/resonance-designs
-# Date: 2025-09-24
+# Optional environment variables:
+#   FRONTEND_FOLDER=docman
+#   CERTBOT_EMAIL=admin@example.com
+#   SSL_DOMAINS="docman.example.com api.docman.example.com"
 
-# --- Configuration (Modify these values according to your setup) ---
-FRONTEND_FOLDER="docman"
-DOMAIN_NAME="example.com"
-CERTBOT_EMAIL="admin@$DOMAIN_NAME"
+DEPLOY_ROOT=/var/www/docman
+BACKEND_DIR="$DEPLOY_ROOT/backend"
+VUE_FRONTEND_DIR="$DEPLOY_ROOT/frontend-vue"
+APACHE_ROOT=/var/www/html
+SERVICE_FILE=/etc/systemd/system/docman-backend.service
+SERVICE_USER=docman
+SERVICE_GROUP=www-data
+MIN_NODE_VERSION=20.19.0
+BACKUP_ROOT=/tmp/docman_env_backup
+FRONTEND_FOLDER="${FRONTEND_FOLDER:-docman}"
+CERTBOT_EMAIL="${CERTBOT_EMAIL:-}"
+SSL_DOMAINS="${SSL_DOMAINS:-}"
 SSL_FLAG=0
 DRY_RUN=0
-DRYRUN_LOG="/tmp/docman_dryrun.log"
+DRYRUN_LOG=/tmp/docman_dryrun.log
+OPERATOR_USER="${SUDO_USER:-${USER:-root}}"
+OPERATOR_HOME="$(getent passwd "$OPERATOR_USER" | cut -d: -f6 2>/dev/null || true)"
+OPERATOR_HOME="${OPERATOR_HOME:-$HOME}"
+ENV_EXPORT_DIR="$OPERATOR_HOME/docman"
+EXPORTED_ENV_SOURCE_FILE="$ENV_EXPORT_DIR/previous-backend.env.prod"
 
-# --- Parse arguments ---
 for arg in "$@"; do
     case $arg in
         --ssl) SSL_FLAG=1 ;;
@@ -49,7 +45,6 @@ for arg in "$@"; do
     esac
 done
 
-# --- Wrapper for commands ---
 run_cmd() {
     if [[ $DRY_RUN -eq 1 ]]; then
         echo "[DRY-RUN] $*" | tee -a "$DRYRUN_LOG"
@@ -58,123 +53,185 @@ run_cmd() {
     fi
 }
 
-# --- Functions ---
+version_ge() {
+    local current="$1"
+    local minimum="$2"
+    [[ "$(printf '%s\n%s\n' "$minimum" "$current" | sort -V | head -n1)" == "$minimum" ]]
+}
+
+check_prerequisites() {
+    if ! command -v node >/dev/null 2>&1; then
+        echo "⚠️ Node.js is not installed."
+        exit 1
+    fi
+
+    local node_version
+    node_version=$(node -v | sed 's/^v//')
+    if ! version_ge "$node_version" "$MIN_NODE_VERSION"; then
+        echo "⚠️ Node.js $node_version found, but DocMan requires >= $MIN_NODE_VERSION for the current Vue/Vite build."
+        exit 1
+    fi
+
+    command -v git >/dev/null 2>&1 || { echo "⚠️ Git is required."; exit 1; }
+    command -v rsync >/dev/null 2>&1 || { echo "⚠️ rsync is required."; exit 1; }
+}
+
+export_env_files_from_target() {
+    local target="$1"
+    local snapshot_root="$ENV_EXPORT_DIR/env-backups/$(basename "$target")_$(date +%F_%H%M%S)"
+    local found_env=false
+
+    [[ -d "$target" ]] || return 0
+
+    mkdir -p "$snapshot_root"
+    mkdir -p "$ENV_EXPORT_DIR"
+
+    while IFS= read -r -d '' env_file; do
+        local rel_path="${env_file#$target/}"
+        local dest_dir="$snapshot_root/$(dirname "$rel_path")"
+        mkdir -p "$dest_dir"
+        cp "$env_file" "$dest_dir/"
+        found_env=true
+
+        if [[ "$rel_path" == "backend/.env.prod" ]]; then
+            cp "$env_file" "$EXPORTED_ENV_SOURCE_FILE"
+        fi
+    done < <(find "$target" -maxdepth 4 -type f -name '.env*' -print0 2>/dev/null)
+
+    if [[ "$found_env" == true ]]; then
+        echo "📦 Exported previous .env files to $snapshot_root"
+        [[ -f "$EXPORTED_ENV_SOURCE_FILE" ]] && echo "🔍 Preserved backend env defaults at $EXPORTED_ENV_SOURCE_FILE"
+    else
+        rmdir "$snapshot_root" 2>/dev/null || true
+    fi
+}
+
+merge_env() {
+    while IFS= read -r key; do
+        [[ -z "$key" ]] && continue
+        if ! grep -q "^${key}=" .env.prod; then
+            local value
+            value=$(grep "^${key}=" .env.sample | cut -d= -f2-)
+            echo "${key}=${value}" >> .env.prod
+        fi
+    done < <(grep -v '^#' .env.sample | cut -d= -f1)
+}
+
+publish_frontend_assets() {
+    local publish_root="$APACHE_ROOT/$FRONTEND_FOLDER"
+
+    run_cmd "mkdir -p '$publish_root/public_html'"
+    run_cmd "mkdir -p '$publish_root/public_html/remote'"
+    run_cmd "mkdir -p '$publish_root/logs'"
+    run_cmd "rsync -a --delete '$VUE_FRONTEND_DIR/dist/' '$publish_root/public_html/'"
+    run_cmd "rsync -a --delete '$VUE_FRONTEND_DIR/dist-remote/remote/' '$publish_root/public_html/remote/'"
+    run_cmd "chown -R www-data:www-data '$publish_root'"
+}
+
 rollback() {
     echo "⚠️ Rolling back update..."
+
     if [[ $DRY_RUN -eq 1 ]]; then
-        echo "[DRY-RUN] Would restore backend, frontend, and restart services." | tee -a "$DRYRUN_LOG"
-        exit 0
+        echo "[DRY-RUN] Would restore backend, env, frontend assets, and restart services." | tee -a "$DRYRUN_LOG"
+        exit 1
     fi
-    # Restore backend
-    rm -rf /var/www/docman
-    mkdir -p /var/www/docman
-    chown -R www-data:www-data /var/www/docman
-    git clone https://github.com/resonance-designs/docman.git /var/www/docman
-    cd /var/www/docman/backend
-    if [[ -f /tmp/docman_env_backup/.env.prod ]]; then
-        cp /tmp/docman_env_backup/.env.prod .env.prod
+
+    rm -rf "$DEPLOY_ROOT"
+    git clone https://github.com/resonance-designs/docman.git "$DEPLOY_ROOT"
+
+    if [[ -f "$BACKUP_ROOT/.env.prod" ]]; then
+        cp "$BACKUP_ROOT/.env.prod" "$BACKEND_DIR/.env.prod"
         echo "✅ Backend .env.prod restored."
     fi
-    # Restore frontend
-    rsync -a --delete /tmp/docman_env_backup/public_html_backup/ /var/www/html/$FRONTEND_FOLDER/public_html/
-    chown -R www-data:www-data /var/www/html/$FRONTEND_FOLDER/public_html
-    # Restart services
+
+    if [[ -d "$BACKUP_ROOT/public_html_backup" ]]; then
+        rsync -a --delete "$BACKUP_ROOT/public_html_backup/" "$APACHE_ROOT/$FRONTEND_FOLDER/public_html/"
+    fi
+
     systemctl restart docman-backend.service
     systemctl reload apache2
     echo "✅ Update rolled back successfully."
     exit 1
 }
 
-merge_env() {
-    for key in $(grep -v '^#' .env.sample | cut -d= -f1); do
-        if ! grep -q "^$key=" .env.prod; then
-            val=$(grep "^$key=" .env.sample | cut -d= -f2-)
-            echo "$key=$val" >> .env.prod
-        fi
-    done
-}
-
-# --- Trap errors for rollback ---
 trap 'echo "❌ Error detected. Rolling back..."; rollback' ERR
 
-# --- Root check ---
 if [[ $EUID -ne 0 && $DRY_RUN -eq 0 ]]; then
-    echo "⚠️ This script must be run as root."
+    echo "⚠️ This script must be run as root unless you are using --dry-run."
     exit 1
 fi
 
-# --- Begin Update ---
-echo "========================================================="
-echo "===    Updating DocMan on Apache Production Server    ==="
-echo "=== Non-Interactive Script with Auto-Rollback Enabled ==="
-[[ $SSL_FLAG -eq 1 ]] && echo "===                Running SSL Updates                ===" || echo "===              Not Running SSL Updates              ==="
-[[ $DRY_RUN -eq 1 ]] && echo "===       DRY-RUN MODE: No changes will be made       ==="
-echo "========================================================="
-echo ""
-echo "This script updates the production version of DocMan running on an Apache server."
-echo ""
-echo "Features:"
-echo "- Performs a non-interactive update to ensure minimal downtime."
-echo "- Automatically rolls back changes if any error occurs during the update process."
-echo "- Supports optional SSL certificate renewal using Certbot."
-echo ""
+check_prerequisites
+
+echo "=============================================================="
+echo "=== Updating DocMan on Apache Production Server (No Prompts) ==="
+[[ $SSL_FLAG -eq 1 ]] && echo "=== SSL update requested ==="
+[[ $DRY_RUN -eq 1 ]] && echo "=== DRY-RUN MODE: no changes will be applied ==="
+echo "=============================================================="
 
 # --- 1️⃣ Backup ---
 echo "1️⃣ Backing up current .env.prod and frontend..."
-if [[ $DRY_RUN -eq 0 && -f /tmp/docman_env_backup/.env.prod ]]; then
-    echo "⚠️ Backup already exists at /tmp/docman_env_backup/.env.prod, skipping overwrite."
+if [[ $DRY_RUN -eq 0 ]]; then
+    mkdir -p "$BACKUP_ROOT"
+    cp "$BACKEND_DIR/.env.prod" "$BACKUP_ROOT/.env.prod"
+    mkdir -p "$BACKUP_ROOT/public_html_backup"
+    rsync -a "$APACHE_ROOT/$FRONTEND_FOLDER/public_html/" "$BACKUP_ROOT/public_html_backup/"
+    export_env_files_from_target "$DEPLOY_ROOT"
 else
-    run_cmd "mkdir -p /tmp/docman_env_backup"
-    run_cmd "cp /var/www/docman/backend/.env.prod /tmp/docman_env_backup/.env.prod"
-    run_cmd "mkdir -p /tmp/docman_env_backup/public_html_backup"
-    run_cmd "rsync -a /var/www/html/$FRONTEND_FOLDER/public_html/ /tmp/docman_env_backup/public_html_backup/"
+    echo "[DRY-RUN] Would back up $BACKEND_DIR/.env.prod and $APACHE_ROOT/$FRONTEND_FOLDER/public_html/" | tee -a "$DRYRUN_LOG"
 fi
 [[ $DRY_RUN -eq 1 ]] && echo "[DRY-RUN] Backup simulated." || echo "✅ Backup complete."
 
-# --- 2️⃣ Clone fresh repository ---
+# --- 2️⃣ Fresh clone ---
 echo ""
 echo "2️⃣ Cloning fresh repository..."
-run_cmd "rm -rf /var/www/docman"
-run_cmd "mkdir -p /var/www/docman"
-run_cmd "chown -R www-data:www-data /var/www/docman"
-run_cmd "git clone https://github.com/resonance-designs/docman.git /var/www/docman"
+run_cmd "rm -rf '$DEPLOY_ROOT'"
+run_cmd "git clone https://github.com/resonance-designs/docman.git '$DEPLOY_ROOT'"
 [[ $DRY_RUN -eq 1 ]] && echo "[DRY-RUN] Repository clone simulated." || echo "✅ Repository cloned fresh."
 
-# --- 3️⃣ Build ---
+# --- 3️⃣ Build Vue frontend and remote bundle ---
 echo ""
-echo "3️⃣ Building application..."
-run_cmd "cd /var/www/docman && npm run build"
+echo "3️⃣ Building Vue frontend and remote bundle..."
+run_cmd "cd '$DEPLOY_ROOT' && npm run build:vue"
+run_cmd "cd '$DEPLOY_ROOT' && npm run build:remote --prefix frontend-vue"
 [[ $DRY_RUN -eq 1 ]] && echo "[DRY-RUN] Build simulated." || echo "✅ Build complete."
 
 # --- 4️⃣ Restore environment ---
 echo ""
 echo "4️⃣ Restoring previous .env.prod..."
-run_cmd "cd /var/www/docman/backend"
-if [[ -f /tmp/docman_env_backup/.env.prod ]]; then
-    run_cmd "cp /tmp/docman_env_backup/.env.prod .env.prod"
-    [[ $DRY_RUN -eq 1 ]] && echo "[DRY-RUN] .env.prod restore simulated." || echo "✅ .env.prod restored."
+run_cmd "cd '$BACKEND_DIR'"
+if [[ -f "$BACKUP_ROOT/.env.prod" ]]; then
+    run_cmd "cp '$BACKUP_ROOT/.env.prod' '$BACKEND_DIR/.env.prod'"
 else
-    run_cmd "cp .env.sample .env.prod"
-    [[ $DRY_RUN -eq 1 ]] && echo "[DRY-RUN] Created .env.prod from sample." || echo "✅ .env.prod created from sample."
+    run_cmd "cp '$BACKEND_DIR/.env.sample' '$BACKEND_DIR/.env.prod'"
 fi
-run_cmd "sed -i '/^#/d;/^$/d' .env.prod"
-run_cmd "sed -i 's/^ACTIVE_ENV=.*/ACTIVE_ENV=1/' .env.prod"
-run_cmd "sed -i 's/^ENV=.*/ENV=Production/' .env.prod"
-run_cmd "sed -i 's/^NODE_ENV=.*/NODE_ENV=production/' .env.prod"
-merge_env
-[[ $DRY_RUN -eq 1 ]] && echo "[DRY-RUN] Environment variables updated." || echo "✅ Environment variables updated."
+run_cmd "cd '$BACKEND_DIR' && sed -i '/^#/d;/^$/d' .env.prod"
+run_cmd "cd '$BACKEND_DIR' && sed -i 's/^ACTIVE_ENV=.*/ACTIVE_ENV=1/' .env.prod"
+run_cmd "cd '$BACKEND_DIR' && sed -i 's/^ENV=.*/ENV=Production/' .env.prod"
+run_cmd "cd '$BACKEND_DIR' && sed -i 's/^NODE_ENV=.*/NODE_ENV=production/' .env.prod"
+if [[ $DRY_RUN -eq 0 ]]; then
+    cd "$BACKEND_DIR"
+    merge_env
+else
+    echo "[DRY-RUN] Would merge missing env keys from .env.sample" | tee -a "$DRYRUN_LOG"
+fi
+[[ $DRY_RUN -eq 1 ]] && echo "[DRY-RUN] Environment update simulated." || echo "✅ Environment variables updated."
 
 # --- 5️⃣ MongoDB ---
 echo ""
 echo "5️⃣ Restarting MongoDB if configured..."
-MONGO_PORT=$(grep "^MONGO_PORT=" .env.prod | cut -d= -f2-)
+if [[ $DRY_RUN -eq 0 ]]; then
+    MONGO_PORT=$(grep '^MONGO_PORT=' "$BACKEND_DIR/.env.prod" | cut -d= -f2-)
+else
+    MONGO_PORT=27017
+fi
 if [[ -f /etc/mongod.conf ]]; then
     run_cmd "systemctl restart mongod"
     if [[ $DRY_RUN -eq 0 ]]; then
         echo "⏳ Waiting for MongoDB on port $MONGO_PORT..."
-        until nc -z localhost $MONGO_PORT; do sleep 1; done
+        until nc -z localhost "$MONGO_PORT"; do sleep 1; done
     else
-        echo "[DRY-RUN] Would wait for MongoDB on port $MONGO_PORT"
+        echo "[DRY-RUN] Would wait for MongoDB on port $MONGO_PORT" | tee -a "$DRYRUN_LOG"
     fi
     [[ $DRY_RUN -eq 1 ]] && echo "[DRY-RUN] MongoDB restart simulated." || echo "✅ MongoDB restarted."
 fi
@@ -182,31 +239,47 @@ fi
 # --- 6️⃣ Backend service ---
 echo ""
 echo "6️⃣ Restarting DocMan backend service..."
+run_cmd "install -d -o www-data -g www-data -m 775 '$BACKEND_DIR/uploads'"
+run_cmd "chown -R '$SERVICE_USER:$SERVICE_GROUP' '$BACKEND_DIR'"
 run_cmd "systemctl daemon-reload"
 run_cmd "systemctl restart docman-backend.service"
 run_cmd "systemctl enable docman-backend.service"
-[[ $DRY_RUN -eq 1 ]] && echo "[DRY-RUN] Backend service restart simulated." || echo "✅ Backend service restarted successfully."
+[[ $DRY_RUN -eq 1 ]] && echo "[DRY-RUN] Backend restart simulated." || echo "✅ Backend service restarted successfully."
 
-# --- 7️⃣ Frontend ---
+# --- 7️⃣ Frontend assets ---
 echo ""
-echo "7️⃣ Updating frontend..."
-run_cmd "rsync -a --delete /var/www/docman/frontend/dist/ /var/www/html/$FRONTEND_FOLDER/public_html/"
-run_cmd "chown -R www-data:www-data /var/www/html/$FRONTEND_FOLDER/public_html"
+echo "7️⃣ Publishing frontend and remote assets..."
+publish_frontend_assets
 run_cmd "systemctl reload apache2"
-[[ $DRY_RUN -eq 1 ]] && echo "[DRY-RUN] Frontend update simulated." || echo "✅ Frontend updated successfully."
+[[ $DRY_RUN -eq 1 ]] && echo "[DRY-RUN] Frontend publish simulated." || echo "✅ Frontend updated successfully."
 
-# --- Optional SSL ---
+# --- 8️⃣ Optional SSL ---
 if [[ $SSL_FLAG -eq 1 ]]; then
+    echo ""
     echo "8️⃣ Updating SSL certificates..."
-    run_cmd "certbot --apache -d \"$DOMAIN_NAME\" --non-interactive --agree-tos -m \"$CERTBOT_EMAIL\""
-    run_cmd "systemctl reload apache2"
+    if [[ -z "$SSL_DOMAINS" || -z "$CERTBOT_EMAIL" ]]; then
+        echo "⚠️ When using --ssl, set SSL_DOMAINS and CERTBOT_EMAIL first."
+        echo "   Example: SSL_DOMAINS=\"docman.example.com api.docman.example.com\" CERTBOT_EMAIL=info@example.com sudo ./apache_production_update_ni.sh --ssl"
+        exit 1
+    fi
+
+    certbot_args=()
+    for domain in $SSL_DOMAINS; do
+        certbot_args+=("-d" "$domain")
+    done
+
+    if [[ $DRY_RUN -eq 1 ]]; then
+        echo "[DRY-RUN] certbot --apache --non-interactive --agree-tos -m '$CERTBOT_EMAIL' ${certbot_args[*]}" | tee -a "$DRYRUN_LOG"
+    else
+        certbot --apache --non-interactive --agree-tos -m "$CERTBOT_EMAIL" "${certbot_args[@]}"
+        systemctl reload apache2
+    fi
     [[ $DRY_RUN -eq 1 ]] && echo "[DRY-RUN] SSL update simulated." || echo "✅ SSL updated."
 fi
 
-# --- Completion ---
 echo ""
 if [[ $DRY_RUN -eq 1 ]]; then
-    echo "✅ DRY-RUN: No changes were applied. Commands logged to $DRYRUN_LOG"
+    echo "✅ DRY-RUN complete. Commands were logged to $DRYRUN_LOG"
 else
-    echo "🎉 DocMan update complete. All steps finished successfully."
+    echo "🎉 DocMan update complete."
 fi

--- a/scripts/security-audit.js
+++ b/scripts/security-audit.js
@@ -4,7 +4,7 @@
  * @script security-audit
  * @description Automated security audit script for dependency scanning and vulnerability detection
  * @author Richard Bakos
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 import { execSync } from 'child_process';

--- a/scripts/update-tests.js
+++ b/scripts/update-tests.js
@@ -4,7 +4,7 @@
  * @file /docman/scripts/update-tests.js
  * @description Script to analyze and update test files to ensure compatibility with current codebase
  * @author DocMan Team
- * @version 2.2.4
+ * @version 2.2.5
  * @license UNLICENSED
  */
 


### PR DESCRIPTION
## Summary

This PR stabilizes the current Linode production deployment path for RDocMan and completes the remaining Authentik integration wiring needed for the live Resonance Designs stack.

## What Changed

### Deployment and recovery tooling
- modernized `apache_production_deploy.sh` for the current Vue and remote bundle deployment flow
- modernized `apache_production_update.sh` and `apache_production_update_ni.sh` to match the same production shape
- preserved discovered `.env*` files under `~/docman/env-backups/`
- added `~/docman/previous-backend.env.prod` as the preferred recovery source for future deploys
- improved reuse of prior production values during recovery prompts

### Production env support
- added `.secrets/.env.prod` as a local ignored production env reference
- wired confirmed production Authentik values into the local production env reference
- updated backend env support to prefer `AUTHENTIK_JWKS_URL` for Authentik token verification

### Authentik integration
- added JWKS-based Authentik token verification support in the backend
- kept PEM-based `AUTHENTIK_JWT_PUBLIC_KEY` support as a fallback
- aligned frontend and backend Authentik configuration with the live `rdocman-web` provider setup

### Documentation and metadata
- updated deployment and release documentation to reflect the actual Linode/AuthentiK/Apache setup flow
- updated README script descriptions to match current behavior
- updated Swagger/OpenAPI metadata to use the correct production contact address and production server labeling
- removed stale `docman.com` assumptions from app-facing metadata
- updated changelog entries to split post-`0.2.4` work into `0.2.5`

## Why

The previous deployment path had drifted from the actual production architecture and produced a fragile recovery experience:
- placeholder `.env` values were being reused incorrectly
- update scripts lagged behind the Vue/remote-bundle deployment shape
- Authentik backend verification still depended on a manually supplied PEM
- Swagger and contact metadata still referenced invalid or stale values

This PR brings the deployment tooling, docs, and Authentik configuration closer to the real production environment currently running on Linode.

## Notes

- `AUTHENTIK_JWT_PUBLIC_KEY` can now remain blank when `AUTHENTIK_JWKS_URL` is provided
- frontend Authentik values are still build-time values and require a rebuild to take effect
- sensitive values referenced during server recovery should still be rotated outside this PR workflow
