### PR TITLE
Release 2.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.2.6] - 2026-04-29
+## [2.2.7] - 2026-04-30
+
+### Changed
+
+- Changed the Authentik backend identity flow to auto-link existing local users by verified email on first sign-in.
+- Changed the Authentik backend identity flow to just-in-time provision new local viewer accounts for verified Authentik identities that do not already exist in MongoDB.
+- Changed the Vue login experience to expose `Create Resonance Account` when an Authentik enrollment URL is configured and to de-emphasize legacy local-only access.
+- Added `LOCAL_SELF_REGISTRATION_ENABLED` so production can disable the legacy local `/auth/register` path when Authentik is the canonical suite registration authority.
+- Updated deployment and recovery documentation to explain the new verified-email auto-linking path, JIT provisioning behavior, and the remaining manual `authentikSub` repair workflow.
+
+## [2.2.6] - 2026-04-29
 
 ### Changed
 
@@ -11,7 +21,7 @@ All notable changes to this project will be documented in this file.
 - Hardened `apache_production_update.sh` and `apache_production_update_ni.sh` to restore from persistent local backups instead of relying on a fresh git clone during rollback.
 - Updated `backend/.env.sample`, `frontend-vue/.env.production.example`, and README guidance to document the real frontend Authentik build env flow.
 
-## [0.2.5] - 2026-04-29
+## [2.2.5] - 2026-04-29
 
 ### Added
 
@@ -29,7 +39,7 @@ All notable changes to this project will be documented in this file.
 - Updated Swagger/OpenAPI metadata to use `info@resonancedesigns.dev`, label the live API correctly as production, and remove stale `docman.com` assumptions.
 - Updated package metadata and backend email fallbacks to use the Resonance Designs contact address consistently.
 
-## [0.2.4] - 2026-04-27
+## [2.2.4] - 2026-04-27
 
 ### Added
 
@@ -51,7 +61,7 @@ All notable changes to this project will be documented in this file.
 - Tightened the documented and scripted Node.js requirement to `20.19+` or `22.12+` for the current Vue/Vite toolchain.
 - Updated deployment documentation and README guidance to reflect the current Vue/Vuetify, Authentik, and hybrid remote-bundle deployment path.
 
-## [0.2.3] - 2026-04-25
+## [2.2.3] - 2026-04-25
 
 ### Added
 
@@ -77,7 +87,7 @@ All notable changes to this project will be documented in this file.
 - The docs build succeeds with a non-fatal webpack warning from `vscode-languageserver-types`.
 - The docs dependency tree currently reports npm audit findings inherited from the Docusaurus install.
 
-## [0.2.2] - 2026-04-25
+## [2.2.2] - 2026-04-25
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 __by Resonance Designs__
 
-![Static Badge](https://img.shields.io/badge/Version-2.2.6-orange)
-![Static Badge](https://img.shields.io/badge/Latest_Release-v2.2.6-green)
+![Static Badge](https://img.shields.io/badge/Version-2.2.7-orange)
+![Static Badge](https://img.shields.io/badge/Latest_Release-v2.2.7-green)
 
 A modern, full-stack document management system built with Node.js, MongoDB, and a frontend currently migrating from React to Vue/Vuetify. DocMan provides secure document storage, collaborative workflows, and comprehensive review management.
 
@@ -137,6 +137,7 @@ VITE_API_URL=http://localhost:5001/api
 VITE_AUTHENTIK_ENABLED=false
 VITE_AUTHENTIK_CLIENT_ID=rdocman-web
 VITE_AUTHENTIK_AUTHORIZATION_URL=https://accounts.resonancedesigns.dev/application/o/authorize/
+VITE_AUTHENTIK_REGISTRATION_URL=https://accounts.resonancedesigns.dev/if/flow/<your-enrollment-flow>/
 VITE_AUTHENTIK_TOKEN_URL=https://accounts.resonancedesigns.dev/application/o/token/
 VITE_AUTHENTIK_REDIRECT_URI=http://localhost:5174/auth/callback
 VITE_AUTHENTIK_SCOPE=openid profile email
@@ -161,12 +162,44 @@ Important:
 * `frontend-vue/.env.production` is intentionally ignored because it is environment-specific.
 * `VITE_*` values are shipped to the browser and must not contain secrets.
 * Pull the Authentik client ID and OIDC endpoints from the `RDocMan Web Provider` overview in Authentik or its OpenID configuration document before filling the file.
+* `VITE_AUTHENTIK_REGISTRATION_URL` should point at the Authentik self-service enrollment flow you want new users to use for suite account creation.
 * The deploy/update scripts should either copy `frontend-vue/.env.production` from the prepared source checkout or generate it from the `VITE_*` values stored in `backend/.env.prod` before the Vite build runs.
 * Changing `frontend-vue/.env.production` requires a frontend rebuild and republish.
 
 The Vue/Vuetify frontend defaults to the current browser hostname on port `5001` during development. This allows both `http://localhost:5174` and `http://127.0.0.1:5174` to call the backend. The backend CORS development allowlist includes both localhost and loopback origins for ports `3000`, `5173`, and `5174`.
 
 When Authentik is enabled in the Vue frontend, the login view will expose a "Sign in with Resonance Account" path. The frontend uses Authorization Code + PKCE and expects the backend to accept Authentik-issued access tokens that resolve to linked local RDocMan users through `authentikSub`.
+
+When `VITE_AUTHENTIK_REGISTRATION_URL` is configured, the login view also exposes a `Create Resonance Account` path for suite-wide account creation in Authentik.
+
+Current Authentik migration reality:
+
+* the Authentik user must already exist
+* if the Authentik token carries a verified email that matches one local `RDocMan` user, the app auto-links that user on first sign-in
+* if the Authentik token carries a verified email and no local `RDocMan` user exists yet, the app just-in-time provisions a new local viewer account
+* the current admin linking flow still expects the real Authentik `sub` claim from the token payload for manual repair, pre-linking, and exceptions
+
+Practical implication:
+
+* most users should no longer need manual linking if Authentik gives the app a usable verified email
+* entering a username or email instead of the real `sub` will still produce a broken manual link
+* once any `authentikSub` value is saved, the current admin UI stops showing that user in the "unlinked" list until the record is corrected
+
+Suite registration authority:
+
+* Authentik should be treated as the canonical place where new suite users create their primary account
+* `RDocMan` should own only the local shadow user/profile/role record for app-specific settings
+* set `LOCAL_SELF_REGISTRATION_ENABLED=false` in production when you want to disable the legacy local `/auth/register` path
+
+How to get the real `sub` today:
+
+* sign in through `Sign in with Resonance Account`
+* preserve the browser network log across the redirect
+* inspect the Authentik token response
+* decode the JWT payload from `access_token` or `id_token`
+* copy the `sub` claim exactly
+
+Do not use the Authentik username, email, or display name as `authentikSub` unless one of those is literally the `sub` claim in the decoded token.
 
 ## 🧭 Suite UI Migration
 

--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -42,6 +42,7 @@ UPSTASH_REDIS_REST_TOKEN=<UPSTASH_REDIS_REST_TOKEN> # Token for Upstash Redis RE
 VITE_AUTHENTIK_ENABLED=false
 VITE_AUTHENTIK_CLIENT_ID=<AUTHENTIK_CLIENT_ID>
 VITE_AUTHENTIK_AUTHORIZATION_URL=https://accounts.resonancedesigns.dev/application/o/authorize/
+VITE_AUTHENTIK_REGISTRATION_URL=<AUTHENTIK_REGISTRATION_URL> # Example: https://accounts.resonancedesigns.dev/if/flow/<your-enrollment-flow>/
 VITE_AUTHENTIK_TOKEN_URL=https://accounts.resonancedesigns.dev/application/o/token/
 VITE_AUTHENTIK_REDIRECT_URI=https://docman.resonancedesigns.dev/auth/callback
 VITE_AUTHENTIK_SCOPE=openid profile email
@@ -49,6 +50,7 @@ VITE_AUTHENTIK_SCOPE=openid profile email
 # Authentication Configuration
 JWT_SECRET=<AUTH_TOKEN> # Preferred JWT secret for production. Use a long secure random value.
 TOKEN_KEY=<AUTH_TOKEN> # Secret key for JWT or other authentication mechanisms. Can be any secure random string.
+LOCAL_SELF_REGISTRATION_ENABLED=true # Set false in production when Authentik is the canonical suite registration authority
 AUTHENTIK_ISSUER=<AUTHENTIK_ISSUER> # Example: https://accounts.resonancedesigns.dev/application/o/rdocman-web/
 AUTHENTIK_AUDIENCE=<AUTHENTIK_AUDIENCE> # Usually the Authentik client ID / audience expected by DocMan
 AUTHENTIK_CLIENT_ID=<AUTHENTIK_CLIENT_ID> # Optional alias to keep client naming explicit

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rd-docman-backend",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rd-docman-backend",
-      "version": "2.2.6",
+      "version": "2.2.7",
       "license": "UNLICENSED",
       "dependencies": {
         "@aws-sdk/client-ses": "^3.864.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rdocman-backend",
   "private": true,
-  "version": "2.2.6",
+  "version": "2.2.7",
   "description": "RDocMan is a document management application for all sorts of documents. Track updates, schedule reviews, categorize, and upload versions of your docs. DocMan hopes to be the most comprehensive piece of software to manage all of your documentation. You can schedule your documentation for review between stakeholders, the original authors, contributors, relevant tech leads, etc... Categorize, analyze, version repositories, and basically everything you would need to keep your documentation well organized, maintained, analyzed, and backed up.",
   "keywords": [
     "Document Management",

--- a/backend/src/__tests__/analytics.test.js
+++ b/backend/src/__tests__/analytics.test.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import request from "supertest";

--- a/backend/src/__tests__/auth.integration.test.js
+++ b/backend/src/__tests__/auth.integration.test.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import request from "supertest";

--- a/backend/src/__tests__/auth.test.js
+++ b/backend/src/__tests__/auth.test.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import request from "supertest";

--- a/backend/src/__tests__/categories.test.js
+++ b/backend/src/__tests__/categories.test.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import request from "supertest";

--- a/backend/src/__tests__/docs.test.js
+++ b/backend/src/__tests__/docs.test.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import request from "supertest";

--- a/backend/src/__tests__/externalContacts.test.js
+++ b/backend/src/__tests__/externalContacts.test.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import request from "supertest";

--- a/backend/src/__tests__/middleware/cacheMiddleware.test.js
+++ b/backend/src/__tests__/middleware/cacheMiddleware.test.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/__tests__/middleware/cacheMiddleware.test.js
  * @description Unit tests for caching middleware
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { jest } from '@jest/globals';

--- a/backend/src/__tests__/middleware/performanceMonitor.test.js
+++ b/backend/src/__tests__/middleware/performanceMonitor.test.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/__tests__/middleware/performanceMonitor.test.js
  * @description Unit tests for performance monitoring middleware
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { jest } from '@jest/globals';

--- a/backend/src/__tests__/notifications.test.js
+++ b/backend/src/__tests__/notifications.test.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import request from "supertest";

--- a/backend/src/__tests__/projects.test.js
+++ b/backend/src/__tests__/projects.test.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import request from "supertest";

--- a/backend/src/__tests__/services/documentService.test.js
+++ b/backend/src/__tests__/services/documentService.test.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/__tests__/services/documentService.test.js
  * @description Unit tests for document service business logic
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { jest } from '@jest/globals';

--- a/backend/src/__tests__/services/identityService.authentik.test.js
+++ b/backend/src/__tests__/services/identityService.authentik.test.js
@@ -1,0 +1,172 @@
+/*
+ * @name identityService Authentik Tests
+ * @file /docman/backend/src/__tests__/services/identityService.authentik.test.js
+ * @description Unit tests for Authentik identity auto-linking and JIT provisioning
+ * @author Richard Bakos
+ * @version 2.2.7
+ * @license UNLICENSED
+ */
+import { jest } from "@jest/globals";
+
+process.env.AUTHENTIK_ISSUER = "https://accounts.resonancedesigns.dev/application/o/rdocman-web/";
+process.env.AUTHENTIK_AUDIENCE = "test-client-id";
+process.env.AUTHENTIK_JWT_PUBLIC_KEY = "test-public-key";
+
+const mockBlacklistedToken = {
+    findOne: jest.fn(),
+};
+
+const mockUser = {
+    findOne: jest.fn(),
+    findById: jest.fn(),
+    create: jest.fn(),
+};
+
+const mockJwt = {
+    verify: jest.fn(),
+    decode: jest.fn(),
+};
+
+jest.unstable_mockModule("../../models/BlacklistedToken.js", () => ({
+    default: mockBlacklistedToken,
+}));
+
+jest.unstable_mockModule("../../models/User.js", () => ({
+    default: mockUser,
+}));
+
+jest.unstable_mockModule("jsonwebtoken", () => ({
+    default: mockJwt,
+}));
+
+const { resolveAuthentikTokenIdentity } = await import("../../services/identityService.js");
+
+function createSelectLeanResult(value) {
+    return {
+        select: jest.fn().mockReturnValue({
+            lean: jest.fn().mockResolvedValue(value),
+        }),
+    };
+}
+
+describe("identityService Authentik resolution", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test("resolves an already-linked Authentik user by sub", async () => {
+        const linkedUser = {
+            _id: "507f1f77bcf86cd799439011",
+            email: "linked@example.com",
+            role: "admin",
+            identityProvider: "authentik",
+            authentikSub: "auth-sub-1",
+        };
+
+        mockJwt.verify.mockReturnValue({
+            iss: process.env.AUTHENTIK_ISSUER,
+            aud: process.env.AUTHENTIK_AUDIENCE,
+            sub: "auth-sub-1",
+            email: "linked@example.com",
+            email_verified: true,
+        });
+
+        mockUser.findOne.mockReturnValueOnce(createSelectLeanResult(linkedUser));
+
+        const result = await resolveAuthentikTokenIdentity("fake-authentik-token");
+
+        expect(result.resolution).toBe("linked-sub");
+        expect(result.user.email).toBe("linked@example.com");
+        expect(mockUser.create).not.toHaveBeenCalled();
+    });
+
+    test("auto-links an existing local user by verified email", async () => {
+        const localUserDoc = {
+            _id: "507f1f77bcf86cd799439012",
+            email: "existing@example.com",
+            username: "existinguser",
+            role: "editor",
+            identityProvider: "local",
+            authentikSub: "",
+            save: jest.fn().mockResolvedValue(true),
+        };
+
+        const hydratedUser = {
+            _id: "507f1f77bcf86cd799439012",
+            email: "existing@example.com",
+            username: "existinguser",
+            role: "editor",
+            identityProvider: "authentik",
+            authentikSub: "auth-sub-2",
+        };
+
+        mockJwt.verify.mockReturnValue({
+            iss: process.env.AUTHENTIK_ISSUER,
+            aud: process.env.AUTHENTIK_AUDIENCE,
+            sub: "auth-sub-2",
+            email: "existing@example.com",
+            email_verified: true,
+        });
+
+        mockUser.findOne
+            .mockReturnValueOnce(createSelectLeanResult(null))
+            .mockResolvedValueOnce(localUserDoc);
+
+        mockUser.findById.mockReturnValueOnce(createSelectLeanResult(hydratedUser));
+
+        const result = await resolveAuthentikTokenIdentity("fake-authentik-token");
+
+        expect(result.resolution).toBe("auto-linked-by-verified-email");
+        expect(localUserDoc.identityProvider).toBe("authentik");
+        expect(localUserDoc.authentikSub).toBe("auth-sub-2");
+        expect(localUserDoc.save).toHaveBeenCalled();
+        expect(result.user.email).toBe("existing@example.com");
+    });
+
+    test("jit provisions a new viewer account when no local user exists", async () => {
+        const createdUser = {
+            _id: "507f1f77bcf86cd799439013",
+        };
+
+        const hydratedUser = {
+            _id: "507f1f77bcf86cd799439013",
+            email: "newuser@example.com",
+            username: "newuser",
+            role: "viewer",
+            identityProvider: "authentik",
+            authentikSub: "auth-sub-3",
+        };
+
+        mockJwt.verify.mockReturnValue({
+            iss: process.env.AUTHENTIK_ISSUER,
+            aud: process.env.AUTHENTIK_AUDIENCE,
+            sub: "auth-sub-3",
+            email: "newuser@example.com",
+            email_verified: true,
+            preferred_username: "newuser",
+            given_name: "New",
+            family_name: "User",
+        });
+
+        mockUser.findOne
+            .mockReturnValueOnce(createSelectLeanResult(null))
+            .mockResolvedValueOnce(null)
+            .mockReturnValueOnce(createSelectLeanResult(null))
+            .mockReturnValueOnce(createSelectLeanResult(null));
+
+        mockUser.create.mockResolvedValue(createdUser);
+        mockUser.findById.mockReturnValueOnce(createSelectLeanResult(hydratedUser));
+
+        const result = await resolveAuthentikTokenIdentity("fake-authentik-token");
+
+        expect(result.resolution).toBe("jit-provisioned");
+        expect(mockUser.create).toHaveBeenCalledWith(expect.objectContaining({
+            email: "newuser@example.com",
+            username: "newuser",
+            role: "viewer",
+            identityProvider: "authentik",
+            authentikSub: "auth-sub-3",
+        }));
+        expect(result.user.email).toBe("newuser@example.com");
+    });
+});

--- a/backend/src/__tests__/services/queryOptimizationService.test.js
+++ b/backend/src/__tests__/services/queryOptimizationService.test.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/__tests__/services/queryOptimizationService.test.js
  * @description Unit tests for query optimization service
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { jest } from '@jest/globals';

--- a/backend/src/__tests__/setup.js
+++ b/backend/src/__tests__/setup.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/__tests__/setup.js
  * @description Global test setup and configuration
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { jest } from '@jest/globals';

--- a/backend/src/__tests__/teams.test.js
+++ b/backend/src/__tests__/teams.test.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import request from "supertest";

--- a/backend/src/__tests__/users.test.js
+++ b/backend/src/__tests__/users.test.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import request from "supertest";

--- a/backend/src/config/database-indexes.js
+++ b/backend/src/config/database-indexes.js
@@ -4,7 +4,7 @@
  * @module database-indexes
  * @description Database index definitions for optimal query performance
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/config/db.js
+++ b/backend/src/config/db.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/config/swagger.js
+++ b/backend/src/config/swagger.js
@@ -4,7 +4,7 @@
  * @module swagger
  * @description OpenAPI/Swagger configuration for comprehensive API documentation
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import swaggerJsdoc from 'swagger-jsdoc';

--- a/backend/src/config/upstash.js
+++ b/backend/src/config/upstash.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import {Ratelimit} from "@upstash/ratelimit";

--- a/backend/src/controllers/analyticsController.js
+++ b/backend/src/controllers/analyticsController.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import Doc from "../models/Doc.js";

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -4,7 +4,7 @@
  * @controller authController
  * @description Authentication controller handling user registration, login, logout, and password reset functionality
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import crypto from "crypto";
@@ -21,6 +21,10 @@ import {
     sanitizeString,
     sanitizeEmail
 } from "../lib/validation.js";
+
+function isLocalSelfRegistrationEnabled() {
+    return process.env.LOCAL_SELF_REGISTRATION_ENABLED !== "false";
+}
 
 /**
  * Helper function to set refresh token cookie
@@ -44,6 +48,12 @@ function setRefreshCookie(res, token) {
  */
 export async function register(req, res) {
     try {
+        if (!isLocalSelfRegistrationEnabled()) {
+            return res.status(403).json({
+                message: "Local self-registration is disabled. Create a Resonance Account through Authentik instead.",
+            });
+        }
+
         const { email, firstname, lastname, username, password, role } = req.body;
 
         // Validation
@@ -302,6 +312,7 @@ export async function getCurrentSession(req, res) {
             identity: req.identity ? {
                 authType: req.identity.authType,
                 provider: req.identity.provider,
+                resolution: req.identity.resolution || null,
             } : null,
         });
     } catch (error) {

--- a/backend/src/controllers/booksController.js
+++ b/backend/src/controllers/booksController.js
@@ -4,7 +4,7 @@
  * @controller booksController
  * @description Book management controller for organizing documents into collections
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import Book from "../models/Book.js";

--- a/backend/src/controllers/categoriesController.js
+++ b/backend/src/controllers/categoriesController.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import Category from "../models/Category.js";

--- a/backend/src/controllers/customChartsController.js
+++ b/backend/src/controllers/customChartsController.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import CustomChart from "../models/CustomChart.js";

--- a/backend/src/controllers/docsController.js
+++ b/backend/src/controllers/docsController.js
@@ -4,7 +4,7 @@
  * @controller docsController
  * @description Document management controller for CRUD operations, file uploads, version control, and review workflows
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import Doc from "../models/Doc.js";

--- a/backend/src/controllers/externalContactsController.js
+++ b/backend/src/controllers/externalContactsController.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import ExternalContact from "../models/ExternalContact.js";

--- a/backend/src/controllers/notificationsController.js
+++ b/backend/src/controllers/notificationsController.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import Notification from "../models/Notification.js";

--- a/backend/src/controllers/profilePictureController.js
+++ b/backend/src/controllers/profilePictureController.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import User from "../models/User.js";

--- a/backend/src/controllers/projectsController.js
+++ b/backend/src/controllers/projectsController.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import Project from "../models/Project.js";

--- a/backend/src/controllers/reviewController.js
+++ b/backend/src/controllers/reviewController.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import ReviewAssignment from "../models/ReviewAssignment.js";

--- a/backend/src/controllers/systemController.js
+++ b/backend/src/controllers/systemController.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import os from 'os';

--- a/backend/src/controllers/teamsController.js
+++ b/backend/src/controllers/teamsController.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import Team from "../models/Team.js";

--- a/backend/src/controllers/uploadFileController.js
+++ b/backend/src/controllers/uploadFileController.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import File from "../models/File.js";  // Your file schema/model

--- a/backend/src/controllers/usersController.js
+++ b/backend/src/controllers/usersController.js
@@ -4,7 +4,7 @@
  * @controller usersController
  * @description User management controller for CRUD operations, profile updates, and user administration
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import bcrypt from "bcrypt";

--- a/backend/src/lib/emailService.js
+++ b/backend/src/lib/emailService.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { SESClient, SendEmailCommand } from "@aws-sdk/client-ses";

--- a/backend/src/lib/errorHandler.js
+++ b/backend/src/lib/errorHandler.js
@@ -4,7 +4,7 @@
  * @module errorHandler
  * @description Standardized error handling and logging utilities for consistent error management
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import fs from 'fs';

--- a/backend/src/lib/globalUtils.js
+++ b/backend/src/lib/globalUtils.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 // backend/src/lib/globalUtils.js

--- a/backend/src/lib/jwtSecret.js
+++ b/backend/src/lib/jwtSecret.js
@@ -4,7 +4,7 @@
  * @module jwtSecret
  * @description Shared JWT secret configuration for token signing and verification
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import dotenv from "dotenv";

--- a/backend/src/lib/secretToken.js
+++ b/backend/src/lib/secretToken.js
@@ -4,7 +4,7 @@
  * @module secretToken
  * @description JWT token utilities for creating, verifying, and blacklisting authentication tokens
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import jwt from "jsonwebtoken";

--- a/backend/src/lib/sharedValidation.js
+++ b/backend/src/lib/sharedValidation.js
@@ -4,7 +4,7 @@
  * @module sharedValidation
  * @description Shared validation utilities for consistent validation across all services
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import validator from 'validator';

--- a/backend/src/lib/utils.js
+++ b/backend/src/lib/utils.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 /**

--- a/backend/src/lib/validation.js
+++ b/backend/src/lib/validation.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 // Server-side validation utilities

--- a/backend/src/middleware/authMid.js
+++ b/backend/src/middleware/authMid.js
@@ -4,7 +4,7 @@
  * @middleware authMid
  * @description JWT authentication middleware for verifying Bearer tokens and protecting routes
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import jwt from "jsonwebtoken";

--- a/backend/src/middleware/authRateLimiter.js
+++ b/backend/src/middleware/authRateLimiter.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { Ratelimit } from "@upstash/ratelimit";

--- a/backend/src/middleware/cacheMiddleware.js
+++ b/backend/src/middleware/cacheMiddleware.js
@@ -4,7 +4,7 @@
  * @middleware cacheMiddleware
  * @description Caching middleware for API responses to improve performance
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 

--- a/backend/src/middleware/inputValidation.js
+++ b/backend/src/middleware/inputValidation.js
@@ -4,7 +4,7 @@
  * @middleware inputValidation
  * @description Centralized input validation middleware for sanitizing and validating all user inputs
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import validator from 'validator';

--- a/backend/src/middleware/performanceMonitor.js
+++ b/backend/src/middleware/performanceMonitor.js
@@ -4,7 +4,7 @@
  * @middleware performanceMonitor
  * @description Performance monitoring middleware for tracking API response times and database query performance
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 

--- a/backend/src/middleware/rateLimiter.js
+++ b/backend/src/middleware/rateLimiter.js
@@ -4,7 +4,7 @@
  * @middleware rateLimiter
  * @description Rate limiting middleware using Redis for preventing API abuse and ensuring fair usage
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import ratelimit from "../config/upstash.js";

--- a/backend/src/middleware/requireRole.js
+++ b/backend/src/middleware/requireRole.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 // middleware/requireRole.js

--- a/backend/src/middleware/securityHeaders.js
+++ b/backend/src/middleware/securityHeaders.js
@@ -4,7 +4,7 @@
  * @middleware securityHeaders
  * @description Comprehensive security headers middleware for protecting against common web vulnerabilities
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 

--- a/backend/src/middleware/uploadMid.js
+++ b/backend/src/middleware/uploadMid.js
@@ -4,7 +4,7 @@
  * @middleware uploadMid
  * @description File upload middleware for handling multipart form data and file validation
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import multer from "multer";

--- a/backend/src/models/BlacklistedToken.js
+++ b/backend/src/models/BlacklistedToken.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from "mongoose";

--- a/backend/src/models/Book.js
+++ b/backend/src/models/Book.js
@@ -4,7 +4,7 @@
  * @model Book
  * @description Book model schema for organizing documents into collections within teams and projects
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from "mongoose";

--- a/backend/src/models/Category.js
+++ b/backend/src/models/Category.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 // backend/src/models/Category.js

--- a/backend/src/models/CustomChart.js
+++ b/backend/src/models/CustomChart.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from "mongoose";

--- a/backend/src/models/Doc.js
+++ b/backend/src/models/Doc.js
@@ -4,7 +4,7 @@
  * @model Doc
  * @description Document model schema for managing document metadata, version history, stakeholders, and review workflows
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 // backend/src/models/Doc.js

--- a/backend/src/models/ExternalContact.js
+++ b/backend/src/models/ExternalContact.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from "mongoose";

--- a/backend/src/models/ExternalContactType.js
+++ b/backend/src/models/ExternalContactType.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from "mongoose";

--- a/backend/src/models/File.js
+++ b/backend/src/models/File.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from "mongoose";

--- a/backend/src/models/Notification.js
+++ b/backend/src/models/Notification.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 // backend/src/models/Notification.js

--- a/backend/src/models/Project.js
+++ b/backend/src/models/Project.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 // backend/src/models/Project.js

--- a/backend/src/models/ReviewAssignment.js
+++ b/backend/src/models/ReviewAssignment.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from "mongoose";

--- a/backend/src/models/Team.js
+++ b/backend/src/models/Team.js
@@ -4,7 +4,7 @@
  * @model Team
  * @description Team model schema for collaborative team management with members, invitations, and project associations
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 // backend/src/models/Team.js

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -4,7 +4,7 @@
  * @model User
  * @description User model schema for authentication, profile management, and role-based access control
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from "mongoose";

--- a/backend/src/routes/analyticsRoutes.js
+++ b/backend/src/routes/analyticsRoutes.js
@@ -4,7 +4,7 @@
  * @routes analyticsRoutes
  * @description Analytics routes for generating reports, metrics, and data visualizations
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/authRoutes.js
+++ b/backend/src/routes/authRoutes.js
@@ -4,7 +4,7 @@
  * @routes authRoutes
  * @description Authentication routes for user registration, login, logout, password reset, and token refresh
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/booksRoutes.js
+++ b/backend/src/routes/booksRoutes.js
@@ -4,7 +4,7 @@
  * @routes booksRoutes
  * @description Book management routes for organizing documents into collections
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/categoriesRoutes.js
+++ b/backend/src/routes/categoriesRoutes.js
@@ -4,7 +4,7 @@
  * @routes categoriesRoutes
  * @description Category management routes for organizing and managing document categories
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/customChartsRoutes.js
+++ b/backend/src/routes/customChartsRoutes.js
@@ -4,7 +4,7 @@
  * @routes customChartsRoutes
  * @description Custom chart routes for creating and managing personalized analytics
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/docsRoutes.js
+++ b/backend/src/routes/docsRoutes.js
@@ -4,7 +4,7 @@
  * @routes docsRoutes
  * @description Document management routes for CRUD operations, file uploads, version control, and review workflows
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/externalContactsRoutes.js
+++ b/backend/src/routes/externalContactsRoutes.js
@@ -4,7 +4,7 @@
  * @routes externalContactsRoutes
  * @description External contact management routes for stakeholder organization
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/notificationsRoutes.js
+++ b/backend/src/routes/notificationsRoutes.js
@@ -4,7 +4,7 @@
  * @routes notificationsRoutes
  * @description Notification routes for managing user notifications and alerts
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/projectsRoutes.js
+++ b/backend/src/routes/projectsRoutes.js
@@ -4,7 +4,7 @@
  * @routes projectsRoutes
  * @description Project management routes for project operations and team assignments
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/reviewRoutes.js
+++ b/backend/src/routes/reviewRoutes.js
@@ -4,7 +4,7 @@
  * @routes reviewRoutes
  * @description Document review routes for managing review workflows and approvals
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/systemRoutes.js
+++ b/backend/src/routes/systemRoutes.js
@@ -4,7 +4,7 @@
  * @routes systemRoutes
  * @description System information routes for health checks, status monitoring, and diagnostics
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/teamsRoutes.js
+++ b/backend/src/routes/teamsRoutes.js
@@ -4,7 +4,7 @@
  * @routes teamsRoutes
  * @description Team management routes for team operations, member management, and collaboration
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/uploadRoutes.js
+++ b/backend/src/routes/uploadRoutes.js
@@ -4,7 +4,7 @@
  * @routes uploadRoutes
  * @description File upload routes for handling document uploads and file management
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/routes/usersRoutes.js
+++ b/backend/src/routes/usersRoutes.js
@@ -4,7 +4,7 @@
  * @routes usersRoutes
  * @description User management routes for CRUD operations, profile updates, and administrative functions
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import express from "express";

--- a/backend/src/scripts/clearData/clearAllCollections.js
+++ b/backend/src/scripts/clearData/clearAllCollections.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearAllCollections.js
  * @description Script to clear all collections from the database
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearBlacklistedTokens.js
+++ b/backend/src/scripts/clearData/clearBlacklistedTokens.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearBlacklistedTokens.js
  * @description Script to clear all blacklisted tokens from the database
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearBooks.js
+++ b/backend/src/scripts/clearData/clearBooks.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearBooks.js
  * @description Script to clear all books from the database
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearCategories.js
+++ b/backend/src/scripts/clearData/clearCategories.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearCategories.js
  * @description Script to clear all categories from the database
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearCustomCharts.js
+++ b/backend/src/scripts/clearData/clearCustomCharts.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearCustomCharts.js
  * @description Script to clear all custom charts from the database
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearDocs.js
+++ b/backend/src/scripts/clearData/clearDocs.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearDocs.js
  * @description Script to clear all documents from the database
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearExternalContactTypes.js
+++ b/backend/src/scripts/clearData/clearExternalContactTypes.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearExternalContactTypes.js
  * @description Script to clear all external contact types from the database
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearExternalContacts.js
+++ b/backend/src/scripts/clearData/clearExternalContacts.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearExternalContacts.js
  * @description Script to clear all external contacts from the database
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearFiles.js
+++ b/backend/src/scripts/clearData/clearFiles.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearFiles.js
  * @description Script to clear all files from the database
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearNotifications.js
+++ b/backend/src/scripts/clearData/clearNotifications.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearNotifications.js
  * @description Script to clear all notifications from the database
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearProjects.js
+++ b/backend/src/scripts/clearData/clearProjects.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearProjects.js
  * @description Script to clear all projects from the database
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearReviewAssignments.js
+++ b/backend/src/scripts/clearData/clearReviewAssignments.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearReviewAssignments.js
  * @description Script to clear all review assignments from the database
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearTeams.js
+++ b/backend/src/scripts/clearData/clearTeams.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearTeams.js
  * @description Script to clear all teams from the database
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/clearData/clearUsers.js
+++ b/backend/src/scripts/clearData/clearUsers.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/clearData/clearUsers.js
  * @description Script to clear all users from the database
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/createBookCategory.js
+++ b/backend/src/scripts/createBookCategory.js
@@ -4,7 +4,7 @@
  * @script createBookCategory
  * @description Script to create a sample Book category for testing
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 

--- a/backend/src/scripts/dummyData/createAllDummyData.js
+++ b/backend/src/scripts/dummyData/createAllDummyData.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createAllDummyData.js
  * @description Script to create dummy data for all collections in the database
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyBlacklistedTokens.js
+++ b/backend/src/scripts/dummyData/createDummyBlacklistedTokens.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyBlacklistedTokens.js
  * @description Script to create dummy blacklisted tokens in the database
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyBooks.js
+++ b/backend/src/scripts/dummyData/createDummyBooks.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyBooks.js
  * @description Script to create dummy books in the database
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyCategories.js
+++ b/backend/src/scripts/dummyData/createDummyCategories.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyCategories.js
  * @description Script to create dummy categories in the database
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyCustomCharts.js
+++ b/backend/src/scripts/dummyData/createDummyCustomCharts.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyCustomCharts.js
  * @description Script to create dummy custom charts in the database
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyDocs.js
+++ b/backend/src/scripts/dummyData/createDummyDocs.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyDocs.js
  * @description Script to create dummy documents in the database
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyExternalContactTypes.js
+++ b/backend/src/scripts/dummyData/createDummyExternalContactTypes.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyExternalContactTypes.js
  * @description Script to create dummy external contact types in the database
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyExternalContacts.js
+++ b/backend/src/scripts/dummyData/createDummyExternalContacts.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyExternalContacts.js
  * @description Script to create dummy external contacts in the database
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyFiles.js
+++ b/backend/src/scripts/dummyData/createDummyFiles.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyFiles.js
  * @description Script to create dummy file records in the database
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyNotifications.js
+++ b/backend/src/scripts/dummyData/createDummyNotifications.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyNotifications.js
  * @description Script to create dummy notifications in the database
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyProjects.js
+++ b/backend/src/scripts/dummyData/createDummyProjects.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyProjects.js
  * @description Script to create dummy projects in the database
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyReviewAssignments.js
+++ b/backend/src/scripts/dummyData/createDummyReviewAssignments.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyReviewAssignments.js
  * @description Script to create dummy review assignments in the database
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyTeams.js
+++ b/backend/src/scripts/dummyData/createDummyTeams.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyTeams.js
  * @description Script to create dummy teams in the database
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/dummyData/createDummyUsers.js
+++ b/backend/src/scripts/dummyData/createDummyUsers.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/dummyData/createDummyUsers.js
  * @description Script to create dummy users in the database
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/scripts/linkAuthentikUsers.js
+++ b/backend/src/scripts/linkAuthentikUsers.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/scripts/linkAuthentikUsers.js
  * @description Bulk link existing DocMan users to Authentik subject IDs through an explicit mapping file
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import fs from "fs";

--- a/backend/src/scripts/migrateCategoryTypes.js
+++ b/backend/src/scripts/migrateCategoryTypes.js
@@ -4,7 +4,7 @@
  * @script migrateCategoryTypes
  * @description Migration script to add type field to existing categories
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 

--- a/backend/src/scripts/migrateReviewFields.js
+++ b/backend/src/scripts/migrateReviewFields.js
@@ -4,7 +4,7 @@
  * @script migrateReviewFields
  * @description Migration script to update documents from old reviewDate field to new review system
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from "mongoose";

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -3,7 +3,7 @@
  * @file /docman/backend/src/server.js
  * @description Main entry point of the DocMan backend application
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { connectDB } from "./config/db.js";

--- a/backend/src/services/documentService.js
+++ b/backend/src/services/documentService.js
@@ -4,7 +4,7 @@
  * @service documentService
  * @description Business logic service for document operations including CRUD, validation, and access control
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from "mongoose";

--- a/backend/src/services/identityService.js
+++ b/backend/src/services/identityService.js
@@ -4,14 +4,15 @@
  * @service identityService
  * @description Transitional identity resolution service for local JWT auth today and shared suite identity providers later
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import jwt from "jsonwebtoken";
-import { createPublicKey } from "node:crypto";
+import { createPublicKey, randomBytes } from "node:crypto";
 import User from "../models/User.js";
 import BlacklistedToken from "../models/BlacklistedToken.js";
 import { TOKEN_KEY } from "../lib/jwtSecret.js";
+import { sanitizeEmail, validateEmail, validateUsername } from "../lib/validation.js";
 
 const USER_SELECT_FIELDS = "-password -refreshTokenHash -resetPasswordToken -resetPasswordExpires";
 const AUTHENTIK_ISSUER = process.env.AUTHENTIK_ISSUER || process.env.AUTHENTIK_BASE_URL || "";
@@ -19,6 +20,7 @@ const AUTHENTIK_AUDIENCE = process.env.AUTHENTIK_AUDIENCE || process.env.AUTHENT
 const AUTHENTIK_JWT_PUBLIC_KEY = normalizePem(process.env.AUTHENTIK_JWT_PUBLIC_KEY || "");
 const AUTHENTIK_JWKS_URL = resolveAuthentikJwksUrl();
 const AUTHENTIK_JWKS_CACHE_TTL_MS = 5 * 60 * 1000;
+const JIT_DEFAULT_ROLE = "viewer";
 
 let authentikJwksCache = {
     fetchedAt: 0,
@@ -67,6 +69,222 @@ function isAuthentikToken(decoded) {
     }
 
     return Boolean(AUTHENTIK_ISSUER && decoded.iss === AUTHENTIK_ISSUER);
+}
+
+function normalizeClaimString(value) {
+    return typeof value === "string" ? value.trim() : "";
+}
+
+function isVerifiedEmail(decoded) {
+    return decoded?.email_verified === true || decoded?.email_verified === "true";
+}
+
+function getNormalizedVerifiedEmail(decoded) {
+    if (!isVerifiedEmail(decoded)) {
+        return "";
+    }
+
+    const candidateEmail = normalizeClaimString(decoded?.email);
+    const validation = validateEmail(candidateEmail);
+    return validation.isValid ? validation.sanitized : "";
+}
+
+function buildJitPassword() {
+    return `Ak!${randomBytes(24).toString("hex")}Z9`;
+}
+
+function buildJitNames(decoded, normalizedEmail) {
+    const fullName = normalizeClaimString(decoded?.name);
+    const givenName = normalizeClaimString(decoded?.given_name);
+    const familyName = normalizeClaimString(decoded?.family_name);
+    const preferredUsername = normalizeClaimString(decoded?.preferred_username);
+    const emailLocalPart = normalizedEmail ? normalizedEmail.split("@")[0] : "";
+
+    let firstname = givenName;
+    let lastname = familyName;
+
+    if (!firstname && fullName) {
+        const [firstToken, ...rest] = fullName.split(/\s+/).filter(Boolean);
+        firstname = firstToken || "";
+        lastname = rest.join(" ");
+    }
+
+    if (!firstname) {
+        firstname = preferredUsername || emailLocalPart || "Authentik";
+    }
+
+    if (!lastname) {
+        lastname = fullName && firstname !== fullName ? fullName.replace(firstname, "").trim() : "";
+    }
+
+    if (!lastname) {
+        lastname = "User";
+    }
+
+    return {
+        firstname: firstname.slice(0, 50),
+        lastname: lastname.slice(0, 50),
+    };
+}
+
+function slugifyUsernameCandidate(value) {
+    const trimmed = normalizeClaimString(value);
+    if (!trimmed) {
+        return "";
+    }
+
+    return trimmed
+        .normalize("NFKD")
+        .replace(/[^\w.\-@ ]+/g, "")
+        .replace(/@/g, "-")
+        .replace(/\s+/g, "-")
+        .replace(/-+/g, "-")
+        .replace(/[._-]{2,}/g, "-")
+        .replace(/^[._-]+|[._-]+$/g, "")
+        .slice(0, 30);
+}
+
+function buildUsernameCandidates(decoded, normalizedEmail, authentikSub) {
+    const candidates = [];
+    const pushCandidate = (value) => {
+        const candidate = slugifyUsernameCandidate(value);
+        if (candidate && !candidates.includes(candidate)) {
+            candidates.push(candidate);
+        }
+    };
+
+    pushCandidate(decoded?.preferred_username);
+    pushCandidate(decoded?.nickname);
+
+    if (normalizedEmail) {
+        pushCandidate(normalizedEmail.split("@")[0]);
+    }
+
+    const givenName = normalizeClaimString(decoded?.given_name);
+    const familyName = normalizeClaimString(decoded?.family_name);
+    if (givenName && familyName) {
+        pushCandidate(`${givenName}.${familyName}`);
+        pushCandidate(`${givenName}-${familyName}`);
+    }
+
+    pushCandidate(decoded?.name);
+    pushCandidate(`authentik-${normalizeClaimString(authentikSub).slice(0, 12)}`);
+
+    return candidates;
+}
+
+async function findAvailableUsername(decoded, normalizedEmail, authentikSub) {
+    const candidates = buildUsernameCandidates(decoded, normalizedEmail, authentikSub);
+
+    for (const candidate of candidates) {
+        if (validateUsername(candidate)) {
+            continue;
+        }
+
+        const existingUser = await User.findOne({ username: candidate }).select("_id").lean();
+        if (!existingUser) {
+            return candidate;
+        }
+
+        for (let counter = 2; counter <= 1000; counter += 1) {
+            const suffix = `${counter}`;
+            const base = candidate.slice(0, Math.max(1, 30 - suffix.length));
+            const suffixedCandidate = `${base}${suffix}`;
+            if (validateUsername(suffixedCandidate)) {
+                continue;
+            }
+
+            const taken = await User.findOne({ username: suffixedCandidate }).select("_id").lean();
+            if (!taken) {
+                return suffixedCandidate;
+            }
+        }
+    }
+
+    throw createAuthError("Unable to generate a unique RDocMan username for the Authentik identity", 500);
+}
+
+async function hydrateRequestUserById(userId) {
+    const user = await User.findById(userId).select(USER_SELECT_FIELDS).lean();
+    return normalizeRequestUser(user);
+}
+
+async function autoLinkUserByVerifiedEmail(decoded) {
+    const normalizedEmail = getNormalizedVerifiedEmail(decoded);
+    if (!normalizedEmail) {
+        return null;
+    }
+
+    const user = await User.findOne({ email: sanitizeEmail(normalizedEmail) });
+    if (!user) {
+        return null;
+    }
+
+    if (user.authentikSub && user.authentikSub !== decoded.sub) {
+        throw createAuthError("The matching RDocMan email is already linked to another Authentik identity", 409);
+    }
+
+    user.identityProvider = "authentik";
+    user.authentikSub = decoded.sub;
+    await user.save();
+
+    return {
+        resolution: "auto-linked-by-verified-email",
+        user: await hydrateRequestUserById(user._id),
+    };
+}
+
+async function provisionUserFromAuthentikClaims(decoded) {
+    const normalizedEmail = getNormalizedVerifiedEmail(decoded);
+    if (!normalizedEmail) {
+        return null;
+    }
+
+    const existingUser = await User.findOne({ email: sanitizeEmail(normalizedEmail) }).select("_id authentikSub").lean();
+    if (existingUser) {
+        return null;
+    }
+
+    const username = await findAvailableUsername(decoded, normalizedEmail, decoded.sub);
+    const { firstname, lastname } = buildJitNames(decoded, normalizedEmail);
+
+    const createdUser = await User.create({
+        email: sanitizeEmail(normalizedEmail),
+        firstname,
+        lastname,
+        username,
+        password: buildJitPassword(),
+        role: JIT_DEFAULT_ROLE,
+        identityProvider: "authentik",
+        authentikSub: decoded.sub,
+    });
+
+    return {
+        resolution: "jit-provisioned",
+        user: await hydrateRequestUserById(createdUser._id),
+    };
+}
+
+async function resolveOrCreateAuthentikUser(decoded) {
+    const existingLinkedUser = await findUserByAuthentikSub(decoded.sub);
+    if (existingLinkedUser) {
+        return {
+            resolution: "linked-sub",
+            user: existingLinkedUser,
+        };
+    }
+
+    const autoLinkedUser = await autoLinkUserByVerifiedEmail(decoded);
+    if (autoLinkedUser) {
+        return autoLinkedUser;
+    }
+
+    const jitProvisionedUser = await provisionUserFromAuthentikClaims(decoded);
+    if (jitProvisionedUser) {
+        return jitProvisionedUser;
+    }
+
+    throw createAuthError("No linked or provisionable RDocMan user for Authentik identity");
 }
 
 /**
@@ -168,16 +386,14 @@ export async function resolveAuthentikTokenIdentity(token) {
         throw createAuthError("Invalid Authentik token");
     }
 
-    const user = await findUserByAuthentikSub(decoded.sub);
-    if (!user) {
-        throw createAuthError("No linked RDocMan user for Authentik identity");
-    }
+    const resolvedIdentity = await resolveOrCreateAuthentikUser(decoded);
 
     return {
         authType: "authentik-jwt",
         provider: "authentik",
+        resolution: resolvedIdentity.resolution,
         tokenClaims: decoded,
-        user,
+        user: resolvedIdentity.user,
     };
 }
 

--- a/backend/src/services/queryOptimizationService.js
+++ b/backend/src/services/queryOptimizationService.js
@@ -4,7 +4,7 @@
  * @service queryOptimizationService
  * @description Optimized database queries with caching and performance monitoring
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import mongoose from 'mongoose';

--- a/backend/src/services/userService.js
+++ b/backend/src/services/userService.js
@@ -4,7 +4,7 @@
  * @service userService
  * @description Business logic service for user operations including CRUD, validation, and access control
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import User from "../models/User.js";

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docman-docs-site",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docman-docs-site",
-      "version": "2.2.6",
+      "version": "2.2.7",
       "dependencies": {
         "@docusaurus/core": "3.9.1",
         "@docusaurus/preset-classic": "3.9.1",

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docman-docs-site",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "private": true,
   "description": "Docusaurus documentation site for DocMan.",
   "scripts": {

--- a/docs/DEVELOPER_ONBOARDING.md
+++ b/docs/DEVELOPER_ONBOARDING.md
@@ -237,7 +237,7 @@ Every file should have a descriptive header:
  * @service documentService
  * @description Business logic for document management operations
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 ```

--- a/docs/deployment/manual-install-update.md
+++ b/docs/deployment/manual-install-update.md
@@ -1,0 +1,167 @@
+# Manual Install / Update
+
+Use this guide when you need to manually update the live `RDocMan` deployment on the server without relying on the deployment/update scripts.
+
+This is the conservative recovery path:
+
+- restore the repo clone
+- preserve the working server env
+- manually deploy the latest code into `/var/www/docman`
+- rebuild the frontend
+- restart the backend
+- verify the app
+
+## 1. Recreate the repo clone
+
+```bash
+cd ~
+mkdir -p ~/git
+git clone https://github.com/resonance-designs/docman.git ~/git/docman
+```
+
+If you need your patched script copies later:
+
+```bash
+cp ~/scripts/docman/apache_production_deploy.sh ~/git/docman/scripts/ 2>/dev/null || true
+cp ~/scripts/docman/apache_production_update.sh ~/git/docman/scripts/ 2>/dev/null || true
+cp ~/scripts/docman/apache_production_update_ni.sh ~/git/docman/scripts/ 2>/dev/null || true
+chmod +x ~/git/docman/scripts/apache_production_*.sh 2>/dev/null || true
+```
+
+## 2. Back up the currently working deployed env files
+
+```bash
+mkdir -p ~/docman/manual-recovery
+cp /var/www/docman/backend/.env.prod ~/docman/manual-recovery/backend.env.prod
+cp /var/www/docman/frontend-vue/.env.production ~/docman/manual-recovery/frontend.env.production 2>/dev/null || true
+```
+
+## 3. Replace deployed code with latest repo code
+
+This keeps your good env files separate first.
+
+```bash
+sudo systemctl stop docman-backend.service
+
+sudo rm -rf /var/www/docman
+sudo mkdir -p /var/www/docman
+sudo rsync -a --exclude '.git' --exclude 'node_modules' --exclude 'dist' --exclude 'dist-remote' ~/git/docman/ /var/www/docman/
+```
+
+## 4. Put the working env files back
+
+```bash
+sudo cp ~/docman/manual-recovery/backend.env.prod /var/www/docman/backend/.env.prod
+sudo cp ~/docman/manual-recovery/frontend.env.production /var/www/docman/frontend-vue/.env.production 2>/dev/null || true
+```
+
+If that frontend file was not copied, regenerate it from backend env:
+
+```bash
+grep '^VITE_' /var/www/docman/backend/.env.prod | sudo tee /var/www/docman/frontend-vue/.env.production >/dev/null
+```
+
+## 5. Install dependencies
+
+```bash
+cd /var/www/docman
+sudo npm ci --prefix backend
+sudo npm ci --include=dev --prefix frontend-vue
+```
+
+## 6. Build frontend and remote bundle
+
+```bash
+cd /var/www/docman
+sudo npm run build:vue
+sudo npm run build:remote --prefix frontend-vue
+```
+
+## 7. Publish frontend assets
+
+```bash
+sudo mkdir -p /var/www/html/docman/public_html
+sudo mkdir -p /var/www/html/docman/public_html/remote
+sudo mkdir -p /var/www/html/docman/logs
+
+sudo rsync -a --delete /var/www/docman/frontend-vue/dist/ /var/www/html/docman/public_html/
+sudo rsync -a --delete /var/www/docman/frontend-vue/dist-remote/remote/ /var/www/html/docman/public_html/remote/
+sudo chown -R www-data:www-data /var/www/html/docman
+```
+
+## 8. Fix backend permissions
+
+```bash
+sudo install -d -o docman -g www-data -m 775 /var/www/docman/backend/uploads
+sudo chown -R docman:www-data /var/www/docman/backend
+```
+
+## 9. Start backend
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl reset-failed docman-backend.service
+sudo systemctl start docman-backend.service
+```
+
+## 10. Verify
+
+```bash
+sudo systemctl status docman-backend.service --no-pager
+sudo journalctl -u docman-backend.service -n 100 --no-pager
+sudo apachectl configtest
+curl -I http://127.0.0.1:5001/
+curl -I http://127.0.0.1:5001/api-docs/
+curl -I https://docman.resonancedesigns.dev
+curl -I https://api.docman.resonancedesigns.dev/api-docs/
+```
+
+## 11. Test login
+
+Open:
+
+- `https://docman.resonancedesigns.dev/login`
+
+You should see:
+
+- local login
+- `Sign in with Resonance Account`
+
+## 12. Authentik migration checks
+
+If the infrastructure is healthy but Authentik sign-in still fails with `401`, walk these checks before assuming the provider config is broken:
+
+- confirm the Authentik user already exists
+- confirm the Authentik token includes a verified email if you expect automatic linking or provisioning
+- confirm the local user is linked to the real Authentik `sub`, or confirm the email match is correct for auto-linking
+- confirm `frontend-vue/.env.production` and `backend/.env.prod` still contain the same Authentik client ID
+
+Current behavior:
+
+- `RDocMan` now auto-links existing local users by verified Authentik email
+- `RDocMan` now just-in-time provisions new local viewer accounts for verified Authentik identities with no local user yet
+- manual `authentikSub` linking is still used for repair work and exceptions
+- Authentik should be treated as the canonical suite account-registration authority
+- set `LOCAL_SELF_REGISTRATION_ENABLED=false` in production if you want to disable legacy local self-registration
+
+Manual `sub` retrieval is still useful when:
+
+- an email is not verified
+- the wrong `authentikSub` was saved earlier
+- you want to pre-link a user before first Authentik sign-in
+
+How to get the real `sub` today:
+
+1. click `Sign in with Resonance Account`
+2. preserve the browser network log across the redirect
+3. inspect the Authentik token response
+4. decode the JWT payload from `access_token` or `id_token`
+5. copy the `sub` claim exactly
+
+Do not use:
+
+- Authentik username
+- email address
+- display name
+
+If a bad `authentikSub` was already saved, the current admin UI may stop showing that user in the unlinked list. In that case, correct the record directly in MongoDB or Compass before retrying Authentik login.

--- a/frontend-vue/.env.production.example
+++ b/frontend-vue/.env.production.example
@@ -5,6 +5,7 @@
 VITE_AUTHENTIK_ENABLED=false
 VITE_AUTHENTIK_CLIENT_ID=<AUTHENTIK_CLIENT_ID>
 VITE_AUTHENTIK_AUTHORIZATION_URL=https://accounts.resonancedesigns.dev/application/o/authorize/
+VITE_AUTHENTIK_REGISTRATION_URL=https://accounts.resonancedesigns.dev/if/flow/<your-enrollment-flow>/
 VITE_AUTHENTIK_TOKEN_URL=https://accounts.resonancedesigns.dev/application/o/token/
 VITE_AUTHENTIK_REDIRECT_URI=https://docman.resonancedesigns.dev/auth/callback
 VITE_AUTHENTIK_SCOPE=openid profile email

--- a/frontend-vue/package-lock.json
+++ b/frontend-vue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rd-docman-frontend-vue",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rd-docman-frontend-vue",
-      "version": "2.2.6",
+      "version": "2.2.7",
       "dependencies": {
         "@mdi/font": "^7.4.47",
         "axios": "^1.11.0",

--- a/frontend-vue/package.json
+++ b/frontend-vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rd-docman-frontend-vue",
   "private": true,
-  "version": "2.2.6",
+  "version": "2.2.7",
   "type": "module",
   "description": "Vue and Vuetify migration foundation for DocMan.",
   "scripts": {

--- a/frontend-vue/src/composables/useAuth.js
+++ b/frontend-vue/src/composables/useAuth.js
@@ -3,8 +3,10 @@ import { api } from '@/services/api';
 import { getStorageKey } from '@/runtime/config';
 import {
   beginAuthentikLogin,
+  beginAuthentikRegistration,
   consumePostLoginRedirect,
   exchangeAuthentikCode,
+  hasAuthentikRegistration,
   isAuthentikEnabled,
 } from '@/services/authentikAuth';
 
@@ -70,6 +72,7 @@ export function useAuth() {
   const isAuthenticated = computed(() => Boolean(state.token));
   const userRole = computed(() => state.user?.role || null);
   const authentikAvailable = computed(() => isAuthentikEnabled());
+  const authentikRegistrationAvailable = computed(() => hasAuthentikRegistration());
 
   async function login(email, password) {
     state.loading = true;
@@ -107,6 +110,11 @@ export function useAuth() {
     await beginAuthentikLogin(redirectPath);
   }
 
+  async function startAuthentikRegistration() {
+    state.error = '';
+    beginAuthentikRegistration();
+  }
+
   async function completeAuthentikLogin(code, returnedState) {
     state.loading = true;
     state.error = '';
@@ -141,10 +149,12 @@ export function useAuth() {
     isAuthenticated,
     userRole,
     authentikAvailable,
+    authentikRegistrationAvailable,
     login,
     logout,
     hasRole,
     startAuthentikLogin,
+    startAuthentikRegistration,
     completeAuthentikLogin,
   };
 }

--- a/frontend-vue/src/runtime/config.js
+++ b/frontend-vue/src/runtime/config.js
@@ -8,6 +8,7 @@ const defaults = {
   authentikEnabled: import.meta.env.VITE_AUTHENTIK_ENABLED === 'true',
   authentikClientId: import.meta.env.VITE_AUTHENTIK_CLIENT_ID || '',
   authentikAuthorizationUrl: import.meta.env.VITE_AUTHENTIK_AUTHORIZATION_URL || '',
+  authentikRegistrationUrl: import.meta.env.VITE_AUTHENTIK_REGISTRATION_URL || '',
   authentikTokenUrl: import.meta.env.VITE_AUTHENTIK_TOKEN_URL || '',
   authentikRedirectUri: import.meta.env.VITE_AUTHENTIK_REDIRECT_URI || '',
   authentikScope: import.meta.env.VITE_AUTHENTIK_SCOPE || 'openid profile email',

--- a/frontend-vue/src/services/authentikAuth.js
+++ b/frontend-vue/src/services/authentikAuth.js
@@ -8,6 +8,7 @@ function getAuthentikConfig() {
     enabled: Boolean(runtimeConfig.authentikEnabled),
     clientId: runtimeConfig.authentikClientId,
     authorizationUrl: runtimeConfig.authentikAuthorizationUrl,
+    registrationUrl: runtimeConfig.authentikRegistrationUrl,
     tokenUrl: runtimeConfig.authentikTokenUrl,
     redirectUri: runtimeConfig.authentikRedirectUri,
     scope: runtimeConfig.authentikScope || 'openid profile email',
@@ -26,6 +27,11 @@ function assertAuthentikConfigured(config) {
 
 export function isAuthentikEnabled() {
   return getAuthentikConfig().enabled;
+}
+
+export function hasAuthentikRegistration() {
+  const config = getAuthentikConfig();
+  return Boolean(config.enabled && config.registrationUrl);
 }
 
 export async function beginAuthentikLogin(redirectPath = '/documents') {
@@ -51,6 +57,17 @@ export async function beginAuthentikLogin(redirectPath = '/documents') {
   });
 
   window.location.assign(`${config.authorizationUrl}?${params.toString()}`);
+}
+
+export function beginAuthentikRegistration() {
+  const config = getAuthentikConfig();
+  assertAuthentikConfigured(config);
+
+  if (!config.registrationUrl) {
+    throw new Error('Authentik registration is not configured.');
+  }
+
+  window.location.assign(config.registrationUrl);
 }
 
 export async function exchangeAuthentikCode(code, returnedState) {

--- a/frontend-vue/src/views/admin/AuthentikLinkingView.vue
+++ b/frontend-vue/src/views/admin/AuthentikLinkingView.vue
@@ -29,7 +29,7 @@
       variant="tonal"
       density="comfortable"
     >
-      This tool performs explicit user-to-subject linking. It does not auto-link accounts silently by email during authentication.
+      Verified Authentik emails now auto-link existing RDocMan users and can provision new viewer accounts on first sign-in. Use this screen for manual pre-linking, exceptions, and repair work.
     </v-alert>
 
     <v-alert

--- a/frontend-vue/src/views/auth/LoginView.vue
+++ b/frontend-vue/src/views/auth/LoginView.vue
@@ -7,7 +7,7 @@
             Sign in to RDocMan
           </v-card-title>
           <v-card-subtitle>
-            Use your Resonance Designs account when available, or keep using the local DocMan login during migration.
+            Use your Resonance Designs account for suite-wide access. Local DocMan sign-in remains available for legacy access and recovery work.
           </v-card-subtitle>
 
           <v-card-text>
@@ -20,6 +20,46 @@
             >
               {{ state.error }}
             </v-alert>
+
+            <v-alert
+              v-if="authentikAvailable"
+              class="mb-4"
+              type="info"
+              variant="tonal"
+              density="comfortable"
+            >
+              Resonance Account is the canonical suite identity. Use it to access all suite apps. Local DocMan credentials are a legacy fallback and do not create a suite-wide account.
+            </v-alert>
+
+            <v-btn
+              v-if="authentikAvailable"
+              color="primary"
+              block
+              prepend-icon="mdi-account-key-outline"
+              :loading="state.loading"
+              @click="submitAuthentik"
+            >
+              Sign in with Resonance Account
+            </v-btn>
+
+            <v-btn
+              v-if="authentikRegistrationAvailable"
+              class="mt-3"
+              color="secondary"
+              variant="tonal"
+              block
+              prepend-icon="mdi-account-plus-outline"
+              :loading="state.loading"
+              @click="createResonanceAccount"
+            >
+              Create Resonance Account
+            </v-btn>
+
+            <div v-if="authentikAvailable" class="my-6 d-flex align-center ga-3">
+              <v-divider />
+              <span class="text-caption text-medium-emphasis">legacy local access</span>
+              <v-divider />
+            </div>
 
             <v-form @submit.prevent="submit">
               <v-text-field
@@ -43,28 +83,11 @@
                 type="submit"
                 block
                 :loading="state.loading"
+                variant="outlined"
               >
                 Sign in with local DocMan account
               </v-btn>
             </v-form>
-
-            <div v-if="authentikAvailable" class="my-6 d-flex align-center ga-3">
-              <v-divider />
-              <span class="text-caption text-medium-emphasis">or</span>
-              <v-divider />
-            </div>
-
-            <v-btn
-              v-if="authentikAvailable"
-              color="secondary"
-              variant="tonal"
-              block
-              prepend-icon="mdi-account-key-outline"
-              :loading="state.loading"
-              @click="submitAuthentik"
-            >
-              Sign in with Resonance Account
-            </v-btn>
           </v-card-text>
         </v-card>
       </v-col>
@@ -79,7 +102,14 @@ import { useAuth } from '@/composables/useAuth';
 
 const route = useRoute();
 const router = useRouter();
-const { login, state, authentikAvailable, startAuthentikLogin } = useAuth();
+const {
+  login,
+  state,
+  authentikAvailable,
+  authentikRegistrationAvailable,
+  startAuthentikLogin,
+  startAuthentikRegistration,
+} = useAuth();
 
 const email = ref('');
 const password = ref('');
@@ -91,5 +121,9 @@ async function submit() {
 
 async function submitAuthentik() {
   await startAuthentikLogin(typeof route.query.redirect === 'string' ? route.query.redirect : '/documents');
+}
+
+async function createResonanceAccount() {
+  await startAuthentikRegistration();
 }
 </script>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rd-docman-frontend",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rd-docman-frontend",
-      "version": "2.2.6",
+      "version": "2.2.7",
       "license": "UNLICENSED",
       "dependencies": {
         "@hookform/resolvers": "^3.3.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rd-docman-frontend",
   "private": true,
-  "version": "2.2.6",
+  "version": "2.2.7",
   "description": "DocMan is a document management application for all sorts of documents. Track updates, schedule reviews, categorize, and upload versions of your docs. DocMan hopes to be the most comprehensive piece of software to manage all of your documentation. You can schedule your documentation for review between stakeholders, the original authors, contributors, relevant tech leads, etc... Categorize, analyze, version repositories, and basically everything you would need to keep your documentation well organized, maintained, analyzed, and backed up.",
   "keywords": [
     "Document Management",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/App.jsx
  * @description Main application component that handles routing and authentication state
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { Route, Routes } from "react-router";

--- a/frontend/src/README.md
+++ b/frontend/src/README.md
@@ -11,7 +11,7 @@ All frontend files should include a comment header with the following format:
  * @page [ComponentName]
  * @description [Brief description of the component/page]
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 ```

--- a/frontend/src/__tests__/hooks/useFormData.test.js
+++ b/frontend/src/__tests__/hooks/useFormData.test.js
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/__tests__/hooks/useFormData.test.js
  * @description Unit tests for useFormData custom hook
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { renderHook, waitFor } from '@testing-library/react';

--- a/frontend/src/__tests__/setup.js
+++ b/frontend/src/__tests__/setup.js
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/__tests__/setup.js
  * @description Global test setup and configuration for React components
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { expect, afterEach, vi } from 'vitest';

--- a/frontend/src/components/AccountNav.jsx
+++ b/frontend/src/components/AccountNav.jsx
@@ -4,7 +4,7 @@
  * @component AccountNav
  * @description Account navigation dropdown component with profile, teams, and projects links
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/BookTable.jsx
+++ b/frontend/src/components/BookTable.jsx
@@ -4,7 +4,7 @@
  * @component BookTable
  * @description Component for displaying a book in a table row with actions.
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/CatTable.jsx
+++ b/frontend/src/components/CatTable.jsx
@@ -4,7 +4,7 @@
  * @component CatTable
  * @description Category table component for displaying and managing document categories
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/DocCard.jsx
+++ b/frontend/src/components/DocCard.jsx
@@ -4,7 +4,7 @@
  * @component DocCard
  * @description Component for displaying a document card with title, author, description, and review date.
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/DocTable.jsx
+++ b/frontend/src/components/DocTable.jsx
@@ -4,7 +4,7 @@
  * @component DocTable
  * @description Component for displaying a document in a table row with actions.
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/DocsNotFound.jsx
+++ b/frontend/src/components/DocsNotFound.jsx
@@ -4,7 +4,7 @@
  * @component DocNotFound
  * @description Empty state component displayed when no documents are found with call-to-action
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { NotebookIcon } from "lucide-react";

--- a/frontend/src/components/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary.jsx
@@ -4,7 +4,7 @@
  * @component ErrorBoundary
  * @description Component for catching and displaying React errors
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import React from "react";

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -4,7 +4,7 @@
  * @component Footer
  * @description Application footer component with copyright information and company branding
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 /**

--- a/frontend/src/components/InlineLoader.jsx
+++ b/frontend/src/components/InlineLoader.jsx
@@ -4,7 +4,7 @@
  * @component InlineLoader
  * @description Component for loading indicators in the UI.
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import React from 'react';

--- a/frontend/src/components/LoadingSpinner.jsx
+++ b/frontend/src/components/LoadingSpinner.jsx
@@ -4,7 +4,7 @@
  * @component LoadingSpinner
  * @description Component for displaying a loading spinner with an optional message. The component can be customized in terms of size, color and whether it should cover the entire screen or not.
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import React from 'react';

--- a/frontend/src/components/NavAdmin.jsx
+++ b/frontend/src/components/NavAdmin.jsx
@@ -4,7 +4,7 @@
  * @component NavAdmin
  * @description Component for displaying navigation links for the admin panel.
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { Link } from "react-router";

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -4,7 +4,7 @@
  * @component Navbar
  * @description Component for the main navigation bar with responsive menu and authentication handling.
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/NotificationBell.jsx
+++ b/frontend/src/components/NotificationBell.jsx
@@ -4,7 +4,7 @@
  * @component NotificationBell
  * @description Notification bell component with dropdown for displaying user notifications
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/PaginatedBookTable.jsx
+++ b/frontend/src/components/PaginatedBookTable.jsx
@@ -4,7 +4,7 @@
  * @component PaginatedBookTable
  * @description Paginated table component for displaying books with sorting, filtering, and bulk actions
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/PaginatedCatTable.jsx
+++ b/frontend/src/components/PaginatedCatTable.jsx
@@ -4,7 +4,7 @@
  * @component PaginatedCatTable
  * @description Component for displaying categories in a paginated table.
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/PaginatedDocTable.jsx
+++ b/frontend/src/components/PaginatedDocTable.jsx
@@ -4,7 +4,7 @@
  * @component PaginatedDocTable
  * @description Paginated table component for displaying documents with sorting, filtering, and bulk actions
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/PaginatedFileVersionTable.jsx
+++ b/frontend/src/components/PaginatedFileVersionTable.jsx
@@ -4,7 +4,7 @@
  * @component PaginatedFileVersionTable
  * @description Paginated and sortable table for document file version history (sortable by Version and Uploaded)
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/PaginatedUserTable.jsx
+++ b/frontend/src/components/PaginatedUserTable.jsx
@@ -4,7 +4,7 @@
  * @component PaginatedUserTable
  * @description Paginated table component for displaying users with administrative controls and filtering
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/ProtectedRoutes.jsx
+++ b/frontend/src/components/ProtectedRoutes.jsx
@@ -4,7 +4,7 @@
  * @component ProtectedRoutes
  * @description Route protection component for handling authentication and authorization
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { Navigate } from "react-router";

--- a/frontend/src/components/RateLimitedUI.jsx
+++ b/frontend/src/components/RateLimitedUI.jsx
@@ -4,7 +4,7 @@
  * @component RateLimitedUI
  * @description Rate limit notification component displayed when API request limits are exceeded
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { ZapIcon } from "lucide-react";

--- a/frontend/src/components/ReviewCompletionToggle.jsx
+++ b/frontend/src/components/ReviewCompletionToggle.jsx
@@ -4,7 +4,7 @@
  * @component ReviewCompletionToggle
  * @description Toggle component for review assignees to mark their review as complete
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState } from "react";

--- a/frontend/src/components/ReviewStatusSummary.jsx
+++ b/frontend/src/components/ReviewStatusSummary.jsx
@@ -4,7 +4,7 @@
  * @component ReviewStatusSummary
  * @description Summary component showing overall review completion status
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { CheckCircleIcon, ClockIcon, UsersIcon } from "lucide-react";

--- a/frontend/src/components/UserTable.jsx
+++ b/frontend/src/components/UserTable.jsx
@@ -4,7 +4,7 @@
  * @component UserTable
  * @description Component for displaying a user in a table row with actions.
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/filters/DateRangeFilter.jsx
+++ b/frontend/src/components/filters/DateRangeFilter.jsx
@@ -4,7 +4,7 @@
  * @component DateRangeFilter
  * @description Date range filter component with calendar picker for filtering by date periods
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { CalendarIcon, XIcon } from "lucide-react";

--- a/frontend/src/components/filters/DropdownFilter.jsx
+++ b/frontend/src/components/filters/DropdownFilter.jsx
@@ -4,7 +4,7 @@
  * @component DropdownFilter
  * @description Dropdown filter component with search functionality for selecting filter options
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { ChevronDownIcon, XIcon } from "lucide-react";

--- a/frontend/src/components/filters/FilterBar.jsx
+++ b/frontend/src/components/filters/FilterBar.jsx
@@ -4,7 +4,7 @@
  * @component FilterBar
  * @description Comprehensive filter bar with search, dropdown filters, date range, and clear all functionality
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { FilterIcon, XIcon } from "lucide-react";

--- a/frontend/src/components/filters/SearchInput.jsx
+++ b/frontend/src/components/filters/SearchInput.jsx
@@ -4,7 +4,7 @@
  * @component SearchInput
  * @description Reusable search input component with clear button and customizable placeholder for filtering data
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { SearchIcon, XIcon } from "lucide-react";

--- a/frontend/src/components/filters/SortableHeader.jsx
+++ b/frontend/src/components/filters/SortableHeader.jsx
@@ -4,7 +4,7 @@
  * @component SortableHeader
  * @description Sortable table header component with visual indicators for column sorting
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { ChevronUpIcon, ChevronDownIcon, ChevronsUpDownIcon } from "lucide-react";

--- a/frontend/src/components/forms/BookBasicFields.jsx
+++ b/frontend/src/components/forms/BookBasicFields.jsx
@@ -4,7 +4,7 @@
  * @component BookBasicFields
  * @description Reusable form component for basic book fields (title, description, category)
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/forms/DocumentBasicFields.jsx
+++ b/frontend/src/components/forms/DocumentBasicFields.jsx
@@ -4,7 +4,7 @@
  * @component DocumentBasicFields
  * @description Reusable form component for basic document fields (title, description, author, category, review date)
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { Controller } from "react-hook-form";

--- a/frontend/src/components/forms/DocumentSelection.jsx
+++ b/frontend/src/components/forms/DocumentSelection.jsx
@@ -4,7 +4,7 @@
  * @component DocumentSelection
  * @description Reusable component for selecting documents using TeamDetailPage pattern with table-based selection
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/components/forms/EnhancedDocumentFields.jsx
+++ b/frontend/src/components/forms/EnhancedDocumentFields.jsx
@@ -4,7 +4,7 @@
  * @component EnhancedDocumentFields
  * @description Enhanced form component for document fields with new review system
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { Controller } from "react-hook-form";

--- a/frontend/src/components/forms/ExternalContactsManager.jsx
+++ b/frontend/src/components/forms/ExternalContactsManager.jsx
@@ -4,7 +4,7 @@
  * @component ExternalContactsManager
  * @description Reusable component for managing external contacts with add, edit, and remove functionality
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { X, Plus, Edit2, Check, XCircle } from "lucide-react";

--- a/frontend/src/components/forms/ReviewAssignments.jsx
+++ b/frontend/src/components/forms/ReviewAssignments.jsx
@@ -4,7 +4,7 @@
  * @component ReviewAssignments
  * @description Reusable component for managing document review assignments with date scheduling and notes
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { Controller } from "react-hook-form";

--- a/frontend/src/components/forms/StakeholderSelection.jsx
+++ b/frontend/src/components/forms/StakeholderSelection.jsx
@@ -4,7 +4,7 @@
  * @component StakeholderSelection
  * @description Reusable component for selecting stakeholders and owners with chip-based UI
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { X } from "lucide-react";

--- a/frontend/src/components/modals/ConfirmationModal.jsx
+++ b/frontend/src/components/modals/ConfirmationModal.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/components/modals/ConfirmationModal.jsx
  * @component ConfirmationModal
  * @description A reusable confirmation modal component for confirming user actions
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import React from 'react';

--- a/frontend/src/components/projects/AddCollaboratorModal.jsx
+++ b/frontend/src/components/projects/AddCollaboratorModal.jsx
@@ -4,7 +4,7 @@
  * @component AddCollaboratorModal
  * @description Modal component for adding collaborators to a project
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/projects/CollaboratorCard.jsx
+++ b/frontend/src/components/projects/CollaboratorCard.jsx
@@ -4,7 +4,7 @@
  * @component CollaboratorCard
  * @description Card component for displaying project collaborators
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { MoreVerticalIcon, UserIcon, MailIcon, PhoneIcon } from 'lucide-react';

--- a/frontend/src/components/projects/ProjectBooksTable.jsx
+++ b/frontend/src/components/projects/ProjectBooksTable.jsx
@@ -4,7 +4,7 @@
  * @component ProjectBooksTable
  * @description Specialized table component for managing books in projects with checkbox selection and bulk actions
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/projects/ProjectCard.jsx
+++ b/frontend/src/components/projects/ProjectCard.jsx
@@ -4,7 +4,7 @@
  * @component ProjectCard
  * @description Project card component displaying project summary, status, priority, and quick actions
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/components/projects/ProjectDocumentsTable.jsx
+++ b/frontend/src/components/projects/ProjectDocumentsTable.jsx
@@ -4,7 +4,7 @@
  * @component ProjectDocumentsTable
  * @description Specialized table component for managing documents in projects with checkbox selection and bulk actions
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/shared/BaseModal.jsx
+++ b/frontend/src/components/shared/BaseModal.jsx
@@ -4,7 +4,7 @@
  * @component BaseModal
  * @description Reusable base modal component with consistent styling and behavior
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useEffect } from "react";

--- a/frontend/src/components/shared/BaseModal.stories.jsx
+++ b/frontend/src/components/shared/BaseModal.stories.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/components/shared/BaseModal.stories.jsx
  * @description Storybook stories for BaseModal component
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState } from 'react';

--- a/frontend/src/components/shared/DataTable.jsx
+++ b/frontend/src/components/shared/DataTable.jsx
@@ -4,7 +4,7 @@
  * @component DataTable
  * @description Reusable data table component with sorting, pagination, and action buttons
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState } from "react";

--- a/frontend/src/components/shared/DataTable.stories.jsx
+++ b/frontend/src/components/shared/DataTable.stories.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/components/shared/DataTable.stories.jsx
  * @description Storybook stories for DataTable component
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState } from 'react';

--- a/frontend/src/components/shared/ErrorBoundary.jsx
+++ b/frontend/src/components/shared/ErrorBoundary.jsx
@@ -4,7 +4,7 @@
  * @component ErrorBoundary
  * @description React error boundary component for graceful error handling and user feedback
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { Component } from "react";

--- a/frontend/src/components/shared/FormField.jsx
+++ b/frontend/src/components/shared/FormField.jsx
@@ -4,7 +4,7 @@
  * @component FormField
  * @description Reusable form field component with consistent styling, validation, and error handling
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import PropTypes from "prop-types";

--- a/frontend/src/components/shared/FormField.stories.jsx
+++ b/frontend/src/components/shared/FormField.stories.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/components/shared/FormField.stories.jsx
  * @description Storybook stories for FormField component
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState } from 'react';

--- a/frontend/src/components/shared/FormModal.jsx
+++ b/frontend/src/components/shared/FormModal.jsx
@@ -4,7 +4,7 @@
  * @component FormModal
  * @description Reusable form modal component with validation, loading states, and error handling
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import PropTypes from "prop-types";

--- a/frontend/src/components/shared/LoadingSpinner.jsx
+++ b/frontend/src/components/shared/LoadingSpinner.jsx
@@ -4,7 +4,7 @@
  * @component LoadingSpinner
  * @description Reusable loading spinner component with various sizes and styles
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import PropTypes from "prop-types";

--- a/frontend/src/components/shared/LoadingSpinner.stories.jsx
+++ b/frontend/src/components/shared/LoadingSpinner.stories.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/components/shared/LoadingSpinner.stories.jsx
  * @description Storybook stories for LoadingSpinner component
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import LoadingSpinner from './LoadingSpinner';

--- a/frontend/src/components/shared/index.js
+++ b/frontend/src/components/shared/index.js
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/components/shared/index.js
  * @description Centralized export for all shared/reusable components
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/system/ConfirmActionModal.jsx
+++ b/frontend/src/components/system/ConfirmActionModal.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/components/system/ConfirmActionModal.jsx
  * @component ConfirmActionModal
  * @description Confirmation modal for dangerous system actions
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import PropTypes from "prop-types";

--- a/frontend/src/components/system/DangerZone.jsx
+++ b/frontend/src/components/system/DangerZone.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/components/system/DangerZone.jsx
  * @component DangerZone
  * @description Danger zone section for system administration with collection clearing and restoration
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState } from "react";

--- a/frontend/src/components/teams/AddMembersModal.jsx
+++ b/frontend/src/components/teams/AddMembersModal.jsx
@@ -4,7 +4,7 @@
  * @component AddMembersModal
  * @description Modal component for adding existing users to a team
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/components/teams/CreateTeamModal.jsx
+++ b/frontend/src/components/teams/CreateTeamModal.jsx
@@ -4,7 +4,7 @@
  * @component CreateTeamModal
  * @description Modal component for creating new teams with form validation and member invitation
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState } from "react";

--- a/frontend/src/components/teams/InviteMemberModal.jsx
+++ b/frontend/src/components/teams/InviteMemberModal.jsx
@@ -4,7 +4,7 @@
  * @component InviteMemberModal
  * @description Modal component for inviting new members to teams with role assignment
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState } from "react";

--- a/frontend/src/components/teams/MemberCard.jsx
+++ b/frontend/src/components/teams/MemberCard.jsx
@@ -4,7 +4,7 @@
  * @component MemberCard
  * @description Card component for displaying team member information
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { MoreVerticalIcon, UserIcon, CrownIcon, ShieldIcon } from "lucide-react";

--- a/frontend/src/components/teams/TeamBooksTable.jsx
+++ b/frontend/src/components/teams/TeamBooksTable.jsx
@@ -4,7 +4,7 @@
  * @component TeamBooksTable
  * @description Specialized table component for managing books in teams with checkbox selection and bulk actions
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/teams/TeamCard.jsx
+++ b/frontend/src/components/teams/TeamCard.jsx
@@ -4,7 +4,7 @@
  * @component TeamCard
  * @description Team card component displaying team info, member count, project count, and management actions
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/components/teams/TeamDocumentsTable.jsx
+++ b/frontend/src/components/teams/TeamDocumentsTable.jsx
@@ -4,7 +4,7 @@
  * @component TeamDocumentsTable
  * @description Specialized table component for managing documents in teams with checkbox selection and bulk actions
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 

--- a/frontend/src/components/teams/TeamProjectsTable.jsx
+++ b/frontend/src/components/teams/TeamProjectsTable.jsx
@@ -4,7 +4,7 @@
  * @component TeamProjectsTable
  * @description Specialized table component for managing projects in teams with checkbox selection and bulk actions
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 

--- a/frontend/src/context/ConfirmationContext.jsx
+++ b/frontend/src/context/ConfirmationContext.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/context/ConfirmationContext.jsx
  * @context ConfirmationContext
  * @description Context provider for confirmation modals
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { createContext, useContext } from 'react';

--- a/frontend/src/context/ThemeContext.jsx
+++ b/frontend/src/context/ThemeContext.jsx
@@ -4,7 +4,7 @@
  * @context ThemeContext
  * @description React context for managing application theme state with persistence and user preferences
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { createContext, useContext, useState, useEffect } from "react";

--- a/frontend/src/hooks/index.js
+++ b/frontend/src/hooks/index.js
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/hooks/index.js
  * @description Centralized export for all custom React hooks
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 

--- a/frontend/src/hooks/useApi.js
+++ b/frontend/src/hooks/useApi.js
@@ -4,7 +4,7 @@
  * @hook useApi
  * @description Custom hook for managing API operations with loading states and error handling
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState, useCallback } from "react";

--- a/frontend/src/hooks/useAutoLogout.jsx
+++ b/frontend/src/hooks/useAutoLogout.jsx
@@ -15,7 +15,7 @@
  *                     Defaults to 15 minutes.
  *
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 // hooks/useAutoLogout.js

--- a/frontend/src/hooks/useConfirmation.js
+++ b/frontend/src/hooks/useConfirmation.js
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/hooks/useConfirmation.js
  * @hook useConfirmation
  * @description Custom hook for handling confirmation modals
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState, useCallback } from 'react';

--- a/frontend/src/hooks/useDocument.js
+++ b/frontend/src/hooks/useDocument.js
@@ -4,7 +4,7 @@
  * @hook useDocument
  * @description Custom hook for loading and managing document data
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState, useEffect, useCallback } from "react";

--- a/frontend/src/hooks/useDocumentManagement.js
+++ b/frontend/src/hooks/useDocumentManagement.js
@@ -4,7 +4,7 @@
  * @hook useDocumentManagement
  * @description Custom hook for managing document selection in book forms
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState, useCallback } from "react";

--- a/frontend/src/hooks/useExternalContacts.js
+++ b/frontend/src/hooks/useExternalContacts.js
@@ -4,7 +4,7 @@
  * @hook useExternalContacts
  * @description Custom hook for managing external contacts in document forms
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState, useCallback } from "react";

--- a/frontend/src/hooks/useFileUpload.js
+++ b/frontend/src/hooks/useFileUpload.js
@@ -4,7 +4,7 @@
  * @hook useFileUpload
  * @description Custom hook for managing file upload state and progress
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState, useCallback } from "react";

--- a/frontend/src/hooks/useFormData.js
+++ b/frontend/src/hooks/useFormData.js
@@ -4,7 +4,7 @@
  * @hook useFormData
  * @description Custom hook for loading common form data (users, categories, external contact types)
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/hooks/useReviewAssignments.js
+++ b/frontend/src/hooks/useReviewAssignments.js
@@ -4,7 +4,7 @@
  * @hook useReviewAssignments
  * @description Custom hook for managing document review assignments and completion status
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState, useEffect, useCallback } from "react";

--- a/frontend/src/hooks/useReviewManagement.js
+++ b/frontend/src/hooks/useReviewManagement.js
@@ -4,7 +4,7 @@
  * @hook useReviewManagement
  * @description Custom hook for managing document review assignments and scheduling
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState, useCallback } from "react";

--- a/frontend/src/hooks/useStakeholderManagement.js
+++ b/frontend/src/hooks/useStakeholderManagement.js
@@ -4,7 +4,7 @@
  * @hook useStakeholderManagement
  * @description Custom hook for managing stakeholders and owners in document forms
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState, useCallback } from "react";

--- a/frontend/src/hooks/useUserRole.js
+++ b/frontend/src/hooks/useUserRole.js
@@ -4,7 +4,7 @@
  * @hook useUserRole
  * @description Custom hook for managing user authentication and role state
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState, useEffect, useCallback } from "react";

--- a/frontend/src/lib/axios.js
+++ b/frontend/src/lib/axios.js
@@ -4,7 +4,7 @@
  * @module AxiosConfig
  * @description Axios HTTP client configuration with base URL, interceptors, and authentication headers
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import axios from "axios";

--- a/frontend/src/lib/documentFormSchema.js
+++ b/frontend/src/lib/documentFormSchema.js
@@ -4,7 +4,7 @@
  * @module documentFormSchema
  * @description Shared validation schemas and constants for document forms
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { z } from "zod";

--- a/frontend/src/lib/globalUtils.js
+++ b/frontend/src/lib/globalUtils.js
@@ -4,7 +4,7 @@
  * @module globalUtils
  * @description Global utility functions for common operations across the application
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 // frontend/src/lib/globalUtils.js

--- a/frontend/src/lib/safeUtils.js
+++ b/frontend/src/lib/safeUtils.js
@@ -4,7 +4,7 @@
  * @module safeUtils
  * @description Safe utility functions to prevent common React errors. These functions ensure data is always in the expected format
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -4,7 +4,7 @@
  * @module utils
  * @description Backend utility functions for object validation and common server-side operations
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 /**

--- a/frontend/src/lib/validation.js
+++ b/frontend/src/lib/validation.js
@@ -4,7 +4,7 @@
  * @module validation
  * @description Form validation utilities with comprehensive validation rules and error handling
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 /**

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { StrictMode } from 'react';

--- a/frontend/src/pages/AdminProjectsPage.jsx
+++ b/frontend/src/pages/AdminProjectsPage.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/pages/AdminProjectsPage.jsx
  * @page AdminProjectsPage
  * @description Admin page for managing all projects in the system
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/AdminTeamsPage.jsx
+++ b/frontend/src/pages/AdminTeamsPage.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/pages/AdminTeamsPage.jsx
  * @page AdminTeamsPage
  * @description Admin page for managing all teams in the system
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/AnalyticsPage.jsx
+++ b/frontend/src/pages/AnalyticsPage.jsx
@@ -4,7 +4,7 @@
  * @page AnalyticsPage
  * @description Analytics dashboard with charts and metrics for document management insights and reporting
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/CreateBookPage.jsx
+++ b/frontend/src/pages/CreateBookPage.jsx
@@ -4,7 +4,7 @@
  * @page CreateBookPage
  * @description Book creation page with form for adding new books using shared design patterns
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState } from "react";

--- a/frontend/src/pages/CreateCatPage.jsx
+++ b/frontend/src/pages/CreateCatPage.jsx
@@ -4,7 +4,7 @@
  * @page CreateCatPage
  * @description Category creation page with form for adding new document categories
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState } from "react";

--- a/frontend/src/pages/CreateDocPage.jsx
+++ b/frontend/src/pages/CreateDocPage.jsx
@@ -4,7 +4,7 @@
  * @page CreateDocPage
  * @description Document creation page with form for uploading files, setting metadata, assigning stakeholders and owners
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useNavigate, Link } from "react-router";

--- a/frontend/src/pages/CreateProjectPage.jsx
+++ b/frontend/src/pages/CreateProjectPage.jsx
@@ -4,7 +4,7 @@
  * @page CreateProjectPage
  * @description Project creation page with form for setting up new projects and team assignments
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/CustomChartsPage.jsx
+++ b/frontend/src/pages/CustomChartsPage.jsx
@@ -4,7 +4,7 @@
  * @page CustomChartPage
  * @description Custom analytics page for creating and viewing personalized data visualizations
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/EditBookPage.jsx
+++ b/frontend/src/pages/EditBookPage.jsx
@@ -4,7 +4,7 @@
  * @page EditBookPage
  * @description Book editing page with form for updating existing books using shared design patterns
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useNavigate, useParams, Link } from "react-router";

--- a/frontend/src/pages/EditCatPage.jsx
+++ b/frontend/src/pages/EditCatPage.jsx
@@ -4,7 +4,7 @@
  * @page EditCatPage
  * @description Category editing page with form for updating existing categories
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/EditDocPage.jsx
+++ b/frontend/src/pages/EditDocPage.jsx
@@ -4,7 +4,7 @@
  * @page EditDocPage
  * @description Document editing page with form validation for updating document metadata, stakeholders, and file versions
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/pages/EditProjectPage.jsx
+++ b/frontend/src/pages/EditProjectPage.jsx
@@ -4,7 +4,7 @@
  * @page EditProjectPage
  * @description Project editing page for updating project details, status, and team members
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/EditTeamPage.jsx
+++ b/frontend/src/pages/EditTeamPage.jsx
@@ -4,7 +4,7 @@
  * @page EditTeamPage
  * @description Team editing page for updating team information and managing member roles
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/ForgotPassPage.jsx
+++ b/frontend/src/pages/ForgotPassPage.jsx
@@ -4,7 +4,7 @@
  * @page ForgotPassPage
  * @description Page component for password reset request functionality
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import React, { useState } from "react";

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -4,7 +4,7 @@
  * @page HomePage
  * @description Main dashboard page displaying document overview, recent documents, and quick access to key features
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -4,7 +4,7 @@
  * @page LoginPage
  * @description Page for user authentication and login.
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 

--- a/frontend/src/pages/ManageExternalContactTypesPage.jsx
+++ b/frontend/src/pages/ManageExternalContactTypesPage.jsx
@@ -4,7 +4,7 @@
  * @page ManageExternalContactTypesPage
  * @description External contact type management page for organizing contact categories
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/pages/MyProfilePage.jsx
+++ b/frontend/src/pages/MyProfilePage.jsx
@@ -4,7 +4,7 @@
  * @page MyProfilePage
  * @description User profile management page for updating personal information and preferences
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/pages/ProjectDetailPage.jsx
+++ b/frontend/src/pages/ProjectDetailPage.jsx
@@ -4,7 +4,7 @@
  * @page ProjectDetailPage
  * @description Project detail page showing project information, documents, and team collaboration
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/pages/ProjectSettingsPage.jsx
+++ b/frontend/src/pages/ProjectSettingsPage.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/pages/ProjectSettingsPage.jsx
  * @page ProjectSettingsPage
  * @description Project settings page for managing project configuration and preferences
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/ProjectsPage.jsx
+++ b/frontend/src/pages/ProjectsPage.jsx
@@ -4,7 +4,7 @@
  * @page ProjectsPage
  * @description Project management page with filtering, search, and project creation for organizing documents by project
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/pages/RegUserPage.jsx
+++ b/frontend/src/pages/RegUserPage.jsx
@@ -4,7 +4,7 @@
  * @page RegUserPage
  * @description User registration page with form validation and account creation functionality
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState } from "react";

--- a/frontend/src/pages/ResetPassPage.jsx
+++ b/frontend/src/pages/ResetPassPage.jsx
@@ -4,7 +4,7 @@
  * @page ResetPassPage
  * @description Password reset page for updating user passwords with secure token validation
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 // ResetPasswordForm.jsx

--- a/frontend/src/pages/SystemInfoPage.jsx
+++ b/frontend/src/pages/SystemInfoPage.jsx
@@ -4,7 +4,7 @@
  * @page SystemInfoPage
  * @description System information dashboard displaying server status, database info, and application metrics
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/pages/TeamDetailPage.jsx
+++ b/frontend/src/pages/TeamDetailPage.jsx
@@ -4,7 +4,7 @@
  * @page TeamDetailPage
  * @description Team detail page displaying team members, projects, and collaboration tools
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/pages/TeamSettingsPage.jsx
+++ b/frontend/src/pages/TeamSettingsPage.jsx
@@ -3,7 +3,7 @@
  * @file /docman/frontend/src/pages/TeamSettingsPage.jsx
  * @page TeamSettingsPage
  * @description Team settings page for managing team configuration and preferences
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/TeamsPage.jsx
+++ b/frontend/src/pages/TeamsPage.jsx
@@ -4,7 +4,7 @@
  * @page TeamsPage
  * @description Team management page displaying user teams with creation, editing, and member management capabilities
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/pages/ViewBookPage.jsx
+++ b/frontend/src/pages/ViewBookPage.jsx
@@ -4,7 +4,7 @@
  * @page ViewBookPage
  * @description Individual book view page showing book details and contained documents
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useState, useEffect } from "react";

--- a/frontend/src/pages/ViewBooksPage.jsx
+++ b/frontend/src/pages/ViewBooksPage.jsx
@@ -4,7 +4,7 @@
  * @page ViewBooksPage
  * @description Books listing page with filtering and management capabilities
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import React, { useState, useEffect } from 'react';

--- a/frontend/src/pages/ViewCatsPage.jsx
+++ b/frontend/src/pages/ViewCatsPage.jsx
@@ -4,7 +4,7 @@
  * @page ViewCatsPage
  * @description Category management page for viewing, creating, and organizing document categories
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/pages/ViewDocPage.jsx
+++ b/frontend/src/pages/ViewDocPage.jsx
@@ -4,7 +4,7 @@
  * @page ViewDocPage
  * @description Document detail page displaying document information, version history, file downloads, and review management
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { Link, useNavigate, useParams } from "react-router";

--- a/frontend/src/pages/ViewDocsPage.jsx
+++ b/frontend/src/pages/ViewDocsPage.jsx
@@ -4,7 +4,7 @@
  * @page ViewDocsPage
  * @description Document listing page with search, filtering, sorting, and bulk operations for managing documents
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/pages/ViewUserPage.jsx
+++ b/frontend/src/pages/ViewUserPage.jsx
@@ -4,7 +4,7 @@
  * @page ViewUserPage
  * @description User detail page displaying user information and administrative actions
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/pages/ViewUsersPage.jsx
+++ b/frontend/src/pages/ViewUsersPage.jsx
@@ -4,7 +4,7 @@
  * @page ViewUsersPage
  * @description User management page with filtering, search, and user administration for system administrators
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { useEffect, useState } from "react";

--- a/frontend/src/themes.js
+++ b/frontend/src/themes.js
@@ -1,6 +1,6 @@
 /*
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 // Theme definitions for the application

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rd-docman",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rd-docman",
-      "version": "2.2.6",
+      "version": "2.2.7",
       "license": "UNLICENSED",
       "devDependencies": {
         "@playwright/test": "^1.42.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rdocman",
   "private": true,
-  "version": "2.2.6",
+  "version": "2.2.7",
   "type": "module",
   "description": "RDocMan is a document management application for all sorts of documents. Track updates, schedule reviews, categorize, and upload versions of your docs. DocMan hopes to be the most comprehensive piece of software to manage all of your documentation. You can schedule your documentation for review between stakeholders, the original authors, contributors, relevant tech leads, etc... Categorize, analyze, version repositories, and basically everything you would need to keep your documentation well organized, maintained, analyzed, and backed up.",
   "keywords": [

--- a/project-config.json
+++ b/project-config.json
@@ -1,5 +1,5 @@
 {
   "author": "Richard Bakos",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "license": "UNLICENSED"
 }

--- a/scripts/apache_production_update.sh
+++ b/scripts/apache_production_update.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
-# ======================================================================
-# === DocMan Production Update Script (Interactive / Modernized)      ===
-# ======================================================================
+# =====================================================================
+# ===  DocMan Production Update Script (Interactive / Modernized)   ===
+# =====================================================================
 #
 # This script updates an existing Apache-hosted DocMan deployment using the
 # current checked-out repository as the source of truth.
@@ -25,7 +25,8 @@ set -euo pipefail
 #   sudo ./scripts/apache_production_update.sh
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SOURCE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SOURCE_ROOT_DEFAULT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SOURCE_ROOT="${DOCMAN_SOURCE_ROOT:-$SOURCE_ROOT_DEFAULT}"
 SOURCE_SNAPSHOT=""
 
 DEPLOY_ROOT=/var/www/docman
@@ -46,6 +47,35 @@ BACKUP_DIR=""
 BACKUP_ENV_FILE=""
 BACKUP_PUBLISH_DIR=""
 BACKUP_SERVICE_FILE=""
+
+is_docman_repo_root() {
+    local candidate="$1"
+    [[ -d "$candidate/backend" && -d "$candidate/frontend-vue" && -f "$candidate/package.json" ]]
+}
+
+resolve_source_root() {
+    if is_docman_repo_root "$SOURCE_ROOT"; then
+        return
+    fi
+
+    if is_docman_repo_root "$PWD"; then
+        SOURCE_ROOT="$PWD"
+        return
+    fi
+
+    if [[ -n "${SUDO_USER:-}" ]]; then
+        local sudo_home
+        sudo_home="$(getent passwd "$SUDO_USER" | cut -d: -f6 2>/dev/null || true)"
+        if [[ -n "$sudo_home" && -d "$sudo_home/git/docman" ]] && is_docman_repo_root "$sudo_home/git/docman"; then
+            SOURCE_ROOT="$sudo_home/git/docman"
+            return
+        fi
+    fi
+
+    echo "⚠️ Could not resolve a valid DocMan source root."
+    echo "   Set DOCMAN_SOURCE_ROOT=/path/to/docman when running this script."
+    exit 1
+}
 
 cleanup_temp() {
     if [[ -n "$SOURCE_SNAPSHOT" && -d "$SOURCE_SNAPSHOT" ]]; then
@@ -244,6 +274,7 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 check_prerequisites
+resolve_source_root
 
 frontend_folder="$FRONTEND_FOLDER_DEFAULT"
 read -p "Enter frontend folder name to update [$FRONTEND_FOLDER_DEFAULT]: " frontend_folder_input

--- a/scripts/apache_production_update_ni.sh
+++ b/scripts/apache_production_update_ni.sh
@@ -19,7 +19,8 @@ set -euo pipefail
 #   SSL_DOMAINS="docman.example.com api.docman.example.com"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SOURCE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SOURCE_ROOT_DEFAULT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SOURCE_ROOT="${DOCMAN_SOURCE_ROOT:-$SOURCE_ROOT_DEFAULT}"
 
 DEPLOY_ROOT=/var/www/docman
 BACKEND_DIR="$DEPLOY_ROOT/backend"
@@ -45,6 +46,35 @@ BACKUP_DIR=""
 BACKUP_ENV_FILE=""
 BACKUP_PUBLISH_DIR=""
 BACKUP_SERVICE_FILE=""
+
+is_docman_repo_root() {
+    local candidate="$1"
+    [[ -d "$candidate/backend" && -d "$candidate/frontend-vue" && -f "$candidate/package.json" ]]
+}
+
+resolve_source_root() {
+    if is_docman_repo_root "$SOURCE_ROOT"; then
+        return
+    fi
+
+    if is_docman_repo_root "$PWD"; then
+        SOURCE_ROOT="$PWD"
+        return
+    fi
+
+    if [[ -n "${SUDO_USER:-}" ]]; then
+        local sudo_home
+        sudo_home="$(getent passwd "$SUDO_USER" | cut -d: -f6 2>/dev/null || true)"
+        if [[ -n "$sudo_home" && -d "$sudo_home/git/docman" ]] && is_docman_repo_root "$sudo_home/git/docman"; then
+            SOURCE_ROOT="$sudo_home/git/docman"
+            return
+        fi
+    fi
+
+    echo "⚠️ Could not resolve a valid DocMan source root."
+    echo "   Set DOCMAN_SOURCE_ROOT=/path/to/docman when running this script."
+    exit 1
+}
 
 for arg in "$@"; do
     case $arg in
@@ -135,6 +165,7 @@ merge_env() {
 
 create_source_snapshot() {
     if [[ $DRY_RUN -eq 1 ]]; then
+        SOURCE_SNAPSHOT="$SOURCE_ROOT"
         echo "[DRY-RUN] Would snapshot source checkout from $SOURCE_ROOT" | tee -a "$DRYRUN_LOG"
         return
     fi
@@ -267,6 +298,7 @@ if [[ $EUID -ne 0 && $DRY_RUN -eq 0 ]]; then
 fi
 
 check_prerequisites
+resolve_source_root
 
 echo "=============================================================="
 echo "=== Updating DocMan on Apache Production Server (No Prompts) ==="

--- a/scripts/security-audit.js
+++ b/scripts/security-audit.js
@@ -4,7 +4,7 @@
  * @script security-audit
  * @description Automated security audit script for dependency scanning and vulnerability detection
  * @author Richard Bakos
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 import { execSync } from 'child_process';

--- a/scripts/update-tests.js
+++ b/scripts/update-tests.js
@@ -4,7 +4,7 @@
  * @file /docman/scripts/update-tests.js
  * @description Script to analyze and update test files to ensure compatibility with current codebase
  * @author DocMan Team
- * @version 2.2.6
+ * @version 2.2.7
  * @license UNLICENSED
  */
 


### PR DESCRIPTION
## Summary

This PR moves RDocMan closer to a suite-first identity model by improving the Authentik onboarding flow, reducing the need for manual subject linking, and clarifying that Authentik is the canonical registration authority for suite users.

## What Changed

### Authentik identity resolution
- added automatic linking of existing local RDocMan users by verified Authentik email on first sign-in
- added just-in-time provisioning of new local viewer users when a verified Authentik identity has no matching local Mongo user yet
- kept explicit `authentikSub` linking in place for repair, exception handling, and pre-linking workflows

### Login and registration UX
- updated the Vue login screen to make `Sign in with Resonance Account` the primary path
- added a `Create Resonance Account` entry point when an Authentik enrollment URL is configured
- de-emphasized legacy local DocMan sign-in as a fallback/recovery path instead of the primary suite onboarding path

### Local self-registration control
- added `LOCAL_SELF_REGISTRATION_ENABLED`
- when disabled, `/api/auth/register` now rejects local self-registration and directs users to create a suite account through Authentik instead

### Configuration
- added `VITE_AUTHENTIK_REGISTRATION_URL` to frontend/runtime env expectations
- updated `.env` templates and sample env guidance to include the Authentik registration flow URL and local registration toggle

### Documentation
- updated README and deployment/manual recovery guidance to reflect:
  - verified-email auto-linking
  - JIT provisioning
  - Authentik as the canonical suite registration authority
  - the remaining manual `authentikSub` repair workflow

### Release notes
- moved this new onboarding/auth-flow work into the `2.2.7` changelog entry

## Why

The previous Authentik flow worked technically, but it still depended too heavily on manual subject discovery and explicit admin linking for normal onboarding. That made suite-wide adoption harder than it needed to be.

This PR improves the real-world experience by letting:
- existing users get linked automatically by verified email
- brand-new suite users get a local RDocMan shadow account on first Authentik sign-in
- admins keep manual linking available only for exceptional cases

That aligns better with the intended long-term architecture:
- Authentik owns suite identity and registration
- each app owns its own local user/profile/role/settings record

## Notes

- auto-linking and JIT provisioning only run when Authentik provides a usable verified email
- manual `authentikSub` linking is still required for some edge cases and repairs
- production deployments should set `LOCAL_SELF_REGISTRATION_ENABLED=false` when local self-registration is no longer desired
- `Create Resonance Account` requires a configured `VITE_AUTHENTIK_REGISTRATION_URL`
